### PR TITLE
Piano Roll context menu now dismisses immediately on MacOS. Cache `Songview::drawGrid` subdivision colors, batch `p.drawLines` calls

### DIFF
--- a/src/rollcheck.cpp
+++ b/src/rollcheck.cpp
@@ -5,6 +5,7 @@
 #include <QKeyEvent>
 #include <QLineEdit>
 #include <QMouseEvent>
+#include <QMenu>
 #include <QPoint>
 #include <QString>
 #include <QTimer>
@@ -227,6 +228,35 @@ int runRollCheck(const QString &projectRoot, const QString &songLabel,
     }
     if (noteB.velocity != 73)
         fail("clicked note's velocity did not latch into the next draw");
+
+    // A right-click on another note while the note menu is open replaces the
+    // popup in one gesture instead of spending the click only dismissing it.
+    sendMouse(roll, QEvent::MouseButtonPress, b.center, Qt::RightButton,
+              Qt::RightButton);
+    sendMouse(roll, QEvent::MouseButtonRelease, b.center, Qt::RightButton,
+              Qt::NoButton);
+    QCoreApplication::processEvents();
+    auto *noteMenu = roll->findChild<QMenu *>();
+    if (!noteMenu || !noteMenu->isVisible()) {
+        fail("right-click did not open the note menu");
+    } else {
+        const QPoint aGlobal = roll->mapToGlobal(a.center);
+        sendMouse(noteMenu, QEvent::MouseButtonPress,
+                  noteMenu->mapFromGlobal(aGlobal), Qt::RightButton,
+                  Qt::RightButton);
+        sendMouse(noteMenu, QEvent::MouseButtonRelease,
+                  noteMenu->mapFromGlobal(aGlobal), Qt::RightButton,
+                  Qt::NoButton);
+        QCoreApplication::processEvents();
+        const std::vector<SongView::NoteId> &selection = view.selection();
+        const SongView::NoteId aId{uint32_t(a.tick), uint8_t(a.key)};
+        if (!noteMenu->isVisible())
+            fail("retargeting hid the open note menu");
+        if (selection.size() != 1 || !(selection.front() == aId))
+            fail("retargeting did not select the new note");
+        noteMenu->hide();
+        QCoreApplication::processEvents();
+    }
 
     // Drag latch: pull note B's velocity handle 20px up (1px = 1 step),
     // 73 -> 93. The latch must follow the dragged value, not the press value.

--- a/src/ui/songview.cpp
+++ b/src/ui/songview.cpp
@@ -31,6 +31,7 @@
 #include <QVBoxLayout>
 #include <QWheelEvent>
 #include <algorithm>
+#include <array>
 #include <climits>
 #include <cmath>
 #include <functional>
@@ -212,36 +213,6 @@ void forEachSubGridLine(const SongView *sv, double t0, double t1,
     }
 }
 
-// Vertical bar/beat grid lines inside rect, with zoom-adaptive sub-beat
-// lines at the snap grid's positions fading lighter per subdivision level.
-void drawGrid(QPainter &p, const SongView *sv, const QRect &rect, int origin)
-{
-    if (!sv->timeline())
-        return;
-    const double t0 = std::max(0.0, sv->tickAtContentX(rect.left() - origin));
-    const double t1 = sv->tickAtContentX(rect.right() - origin) + 1;
-    const bool drawBeats = sv->pxPerBeat() >= 10.0;
-    const QColor barColor = sv->palette().color(QPalette::Mid);
-    QColor beatColor = barColor;
-    beatColor.setAlpha(70);
-
-    QColor subColor = barColor;
-    forEachSubGridLine(sv, t0, t1, [&](uint64_t tick, int level) {
-        const int x = origin + sv->contentX(double(tick));
-        subColor.setAlpha(level == 1 ? 48 : level == 2 ? 34 : 22);
-        p.setPen(subColor);
-        p.drawLine(x, rect.top(), x, rect.bottom());
-    });
-
-    sv->forEachGridLine(uint64_t(t0), uint64_t(t1),
-                        [&](uint64_t tick, bool isBar, int) {
-                            if (!isBar && !drawBeats)
-                                return;
-                            const int x = origin + sv->contentX(double(tick));
-                            p.setPen(isBar ? barColor : beatColor);
-                            p.drawLine(x, rect.top(), x, rect.bottom());
-                        });
-}
 
 /**
  *  macOS flashes a triggered menu item for 80 ms before hiding the menu.
@@ -956,7 +927,7 @@ protected:
             }
         }
 
-        drawGrid(p, m_sv, grid, kKeyboardW);
+        m_sv->drawGrid(p, grid, kKeyboardW);
 
         // Notes: ghost pass (unselected tracks), then the selected track.
         const SongViewModel &model = m_sv->model();
@@ -3203,7 +3174,7 @@ private:
         }
 
         p.setClipRect(plot);
-        drawGrid(p, m_sv, plot, kGutterW);
+        m_sv->drawGrid(p, plot, kGutterW);
 
         if (row.kind == Row::Voice)
             paintVoiceRow(p, plot);
@@ -3964,9 +3935,67 @@ void TrackHeaderRow::mouseReleaseEvent(QMouseEvent *event)
 
 using namespace songview;
 
+// Vertical bar/beat grid lines inside rect, with zoom-adaptive sub-beat
+// lines at the snap grid's positions fading lighter per subdivision level.
+void SongView::drawGrid(QPainter &p, const QRect &rect, int origin) const
+{
+    if (!timeline())
+        return;
+    enum class GridLineBatch : size_t {
+        SubdivisionLevel1,
+        SubdivisionLevel2,
+        SubdivisionLevel3,
+        Beat,
+        Bar,
+        Count,
+    };
+    constexpr auto batchCount = static_cast<size_t>(GridLineBatch::Count);
+    const auto t0 = std::max(0.0, tickAtContentX(rect.left() - origin));
+    const auto t1 = tickAtContentX(rect.right() - origin) + 1;
+    const auto drawBeats = pxPerBeat() >= 10.0;
+    const auto barColor = palette().color(QPalette::Mid);
+    auto beatColor = barColor;
+    beatColor.setAlpha(70);
+    auto lineBatches = std::array<QVector<QLine>, batchCount>{};
+    forEachSubGridLine(this, t0, t1, [&](uint64_t tick, int level) {
+        const auto batch = static_cast<GridLineBatch>(level - 1);
+        const auto batchIndex = static_cast<size_t>(batch);
+        const auto x = origin + contentX(double(tick));
+        lineBatches[batchIndex].append(
+            QLine(x, rect.top(), x, rect.bottom()));
+    });
+    forEachGridLine(uint64_t(t0), uint64_t(t1),
+                    [&](uint64_t tick, bool isBar, int) {
+                        if (!isBar && !drawBeats)
+                            return;
+                        const auto batch = isBar ? GridLineBatch::Bar
+                                                 : GridLineBatch::Beat;
+                        const auto batchIndex = static_cast<size_t>(batch);
+                        const auto x = origin + contentX(double(tick));
+                        lineBatches[batchIndex].append(
+                            QLine(x, rect.top(), x, rect.bottom()));
+                    });
+    const auto colors = std::array{m_subGridColors[0], m_subGridColors[1],
+                                   m_subGridColors[2], beatColor, barColor};
+    for (auto batchIndex = size_t{0}; batchIndex < lineBatches.size();
+         ++batchIndex) {
+        if (lineBatches[batchIndex].isEmpty())
+            continue;
+        p.setPen(colors[batchIndex]);
+        p.drawLines(lineBatches[batchIndex]);
+    }
+}
+
 SongView::SongView(QWidget *parent)
     : QWidget(parent)
 {
+    const auto lineColor = palette().color(QPalette::Mid);
+    m_subGridColors[0] = lineColor;
+    m_subGridColors[0].setAlpha(48);
+    m_subGridColors[1] = lineColor;
+    m_subGridColors[1].setAlpha(34);
+    m_subGridColors[2] = lineColor;
+    m_subGridColors[2].setAlpha(22);
     auto *vbox = new QVBoxLayout(this);
     vbox->setContentsMargins(0, 0, 0, 0);
     vbox->setSpacing(0);

--- a/src/ui/songview.cpp
+++ b/src/ui/songview.cpp
@@ -19,6 +19,7 @@
 #include <QPaintEvent>
 #include <QPainter>
 #include <QPainterPath>
+#include <QProxyStyle>
 #include <QResizeEvent>
 #include <QScrollArea>
 #include <QScrollBar>
@@ -32,7 +33,9 @@
 #include <algorithm>
 #include <climits>
 #include <cmath>
+#include <functional>
 #include <map>
+#include <utility>
 
 #include "core/mid2agbtables.h"
 #include "core/songdocument.h"
@@ -239,6 +242,92 @@ void drawGrid(QPainter &p, const SongView *sv, const QRect &rect, int origin)
                             p.drawLine(x, rect.top(), x, rect.bottom());
                         });
 }
+
+/**
+ *  macOS flashes a triggered menu item for 80 ms before hiding the menu.
+ * This overrides that.
+ *  */
+class NoteMenuStyle final : public QProxyStyle {
+public:
+  NoteMenuStyle() : QProxyStyle(QApplication::style()->name()) {}
+
+  int styleHint(StyleHint hint, const QStyleOption *option,
+                const QWidget *widget,
+                QStyleHintReturn *returnData) const override {
+    if (hint == SH_Menu_FlashTriggeredItem)
+      return 0;
+    return QProxyStyle::styleHint(hint, option, widget, returnData);
+  }
+};
+
+enum class NoteMenuChoice {
+  None,
+  Velocity,
+  Copy,
+  Cut,
+  Delete,
+};
+// Kept alive by PianoRoll so opening it does not reconstruct its actions.
+class NoteContextMenu final : public QMenu
+{
+public:
+    // Called when an outside right-click should move the menu to another note.
+    explicit NoteContextMenu(
+        QWidget *parent, std::function<void(QPoint)> onOutsideRightClick)
+        : QMenu(parent),
+          m_onOutsideRightClick(std::move(onOutsideRightClick))
+    {
+        auto *menuStyle = new NoteMenuStyle;
+        menuStyle->setParent(this);
+        setStyle(menuStyle);
+        m_velocityAction = addAction(QString());
+        addSeparator();
+        m_copyAction = addAction(SongView::tr("Copy"));
+        m_copyAction->setShortcut(QKeySequence::Copy);
+        m_cutAction = addAction(SongView::tr("Cut"));
+        m_cutAction->setShortcut(QKeySequence::Cut);
+        m_deleteAction = addAction(SongView::tr("Delete"));
+    }
+
+    void showMenuAt(QPoint globalPos, int velocity)
+    {
+        m_velocityAction->setText(
+            SongView::tr("Set Velocity (%1)").arg(velocity));
+        popup(globalPos);
+    }
+
+    NoteMenuChoice handleAction(QAction *action) const
+    {
+        if (action == m_velocityAction)
+            return NoteMenuChoice::Velocity;
+        if (action == m_copyAction)
+            return NoteMenuChoice::Copy;
+        if (action == m_cutAction)
+            return NoteMenuChoice::Cut;
+        if (action == m_deleteAction)
+            return NoteMenuChoice::Delete;
+        return NoteMenuChoice::None;
+    }
+
+protected:
+    void mousePressEvent(QMouseEvent *event) override // If user clicks on a different note while popup is up, refocus, dont close menu
+    {
+        if (event->button() == Qt::RightButton
+            && !rect().contains(event->position().toPoint())) {
+            m_onOutsideRightClick(event->globalPosition().toPoint());
+            event->accept();
+            return;
+        }
+        QMenu::mousePressEvent(event);
+    }
+
+private:
+    std::function<void(QPoint)> m_onOutsideRightClick;
+    QAction *m_velocityAction = nullptr;
+    QAction *m_copyAction = nullptr;
+    QAction *m_cutAction = nullptr;
+    QAction *m_deleteAction = nullptr;
+};
 
 } // namespace
 
@@ -820,8 +909,12 @@ public:
         setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
         setMouseTracking(true);
         setFocusPolicy(Qt::ClickFocus);
+        m_noteMenu = new NoteContextMenu(
+            this, [this](QPoint globalPos) { moveNoteMenu(globalPos); });
+        connect(m_noteMenu, &QMenu::triggered, this, [this](QAction *action) {
+            handleNoteMenuChoice(m_noteMenu->handleAction(action));
+        });
     }
-
     // A mouse gesture is live (pan, note move/resize/velocity/draw, band or
     // time-selection sweep, a still-undecided press, keyboard gliss); the
     // playhead follow-scroll pauses while one runs so the view doesn't jump
@@ -1751,7 +1844,7 @@ private:
                      std::max(2, m_sv->keyHeight() - 1));
     }
 
-    void showNoteMenu(QPoint pos)
+    void showNoteMenu(QPoint localPos)
     {
         SongDocument *doc = m_sv->document();
         if (!doc)
@@ -1759,38 +1852,57 @@ private:
         const std::vector<DocNote> notes = resolveSelection();
         if (notes.empty())
             return;
-        QMenu menu(this);
-        QAction *velocity = menu.addAction(
-            SongView::tr("Set velocity… (%1)").arg(notes.front().velocity));
-        QAction *copy = menu.addAction(SongView::tr("Copy"));
-        copy->setShortcut(QKeySequence::Copy);
-        QAction *cut = menu.addAction(SongView::tr("Cut"));
-        cut->setShortcut(QKeySequence::Cut);
-        QAction *del = menu.addAction(SongView::tr("Delete"));
-        QAction *chosen = menu.exec(mapToGlobal(pos));
-        if (chosen == copy) {
-            copyNotes(notes);
-        } else if (chosen == cut) {
-            copyNotes(notes);
-            doc->deleteNotes(notes);
-            m_sv->clearSelection();
-        } else if (chosen == velocity) {
-            bool ok = false;
-            const int v = QInputDialog::getInt(
-                this, SongView::tr("Note velocity"),
-                SongView::tr("Velocity (1-127, plays as %1-127 in steps of 4):")
-                    .arg(mid2agbEffectiveVelocity(1)),
-                notes.front().velocity, 1, 127, 1, &ok);
-            if (ok) {
-                doc->setNotesVelocity(notes, uint8_t(v));
-                m_lastVelocity = uint8_t(v);
-            }
-        } else if (chosen == del) {
-            doc->deleteNotes(notes);
-            m_sv->clearSelection();
-        }
+        m_noteMenu->showMenuAt(mapToGlobal(localPos), notes.front().velocity);
     }
-
+    void moveNoteMenu(QPoint globalPos)
+    {
+        const QPoint pos = mapFromGlobal(globalPos);
+        const ViewNote *hit = m_sv->document() ? hitNote(pos) : nullptr;
+        if (!hit)
+            return;
+        if (!m_sv->isSelected(*hit))
+            m_sv->setSelection({{hit->startTick, hit->key}});
+        showNoteMenu(pos);
+        update();
+    }
+    void handleNoteMenuChoice(NoteMenuChoice choice)
+    {
+      SongDocument *doc = m_sv->document();
+      if (!doc)
+          return;
+      const auto notes = resolveSelection();
+      if (notes.empty())
+          return;
+      switch (choice) {
+      case NoteMenuChoice::Copy:
+          copyNotes(notes);
+          break;
+      case NoteMenuChoice::Cut:
+          copyNotes(notes);
+          doc->deleteNotes(notes);
+          m_sv->clearSelection();
+          break;
+      case NoteMenuChoice::Velocity: {
+          bool ok = false;
+          const int velocity = QInputDialog::getInt(
+              this, SongView::tr("Note velocity"),
+              SongView::tr("Velocity (1-127, plays as %1-127 in steps of 4):")
+                  .arg(mid2agbEffectiveVelocity(1)),
+              notes.front().velocity, 1, 127, 1, &ok);
+          if (ok) {
+              doc->setNotesVelocity(notes, uint8_t(velocity));
+              m_lastVelocity = uint8_t(velocity);
+          }
+          break;
+      }
+      case NoteMenuChoice::Delete:
+          doc->deleteNotes(notes);
+          m_sv->clearSelection();
+          break;
+      case NoteMenuChoice::None:
+          break;
+      }
+    }
     void drawKeyboard(QPainter &p)
     {
         const int keyH = m_sv->keyHeight();
@@ -1917,6 +2029,7 @@ private:
                                   // clicked/velocity-edited note
     bool m_panning = false;    // middle-drag pan
     QPoint m_panPos;           // last pan sample, global coords
+    NoteContextMenu *m_noteMenu = nullptr;
 };
 
 // ----------------------------------------------------------- AutomationArea

--- a/src/ui/songview.h
+++ b/src/ui/songview.h
@@ -5,6 +5,7 @@
 #include <QList>
 #include <QSet>
 #include <QWidget>
+#include <array>
 #include <cstdint>
 #include <functional>
 #include <utility>
@@ -22,6 +23,8 @@ class QKeyEvent;
 class QScrollArea;
 class QScrollBar;
 class QSplitter;
+class QPainter;
+class QRect;
 class QStackedWidget;
 class SongDocument;
 
@@ -214,6 +217,7 @@ public:
     // barNumber) for every beat, honoring the song's time signature changes.
     void forEachGridLine(uint64_t tickBegin, uint64_t tickEnd,
                          const std::function<void(uint64_t, bool, int)> &fn) const;
+    void drawGrid(QPainter &p, const QRect &rect, int origin) const;
 
     // --- editing support for the child widgets ---
     // Snap-grid feel and floor (the ruler's grid controls): the zoom-adaptive
@@ -477,6 +481,7 @@ private:
     GridFeel m_gridFeel = GridFeel::Straight;
     int m_gridMinDenom = 0; // note denominator; 0 = clock-grid floor
     std::vector<std::pair<int, uint8_t>> m_emptyLanes; // (track, cc), unsorted
+    std::array<QColor, 3> m_subGridColors;
 
     songview::TimeRuler *m_ruler = nullptr;
     songview::TrackHeaderPanel *m_headers = nullptr;


### PR DESCRIPTION
Contributing a potential fix for making deletion of notes feel faster.
I have **not** tested on Windows.
Currently, on Mac OS, when right-clicking a note and hitting any action on the context menu, the context menu delays the selected action for a noticeable amount of time.
These changes to the context menu make it almost instantly go away when you click an action.

The difference comes from adding this style to the QMenu that is the context menu:
```c++
class NoteMenuStyle final : public QProxyStyle {
public:
  NoteMenuStyle() : QProxyStyle(QApplication::style()->name()) {}

  int styleHint(StyleHint hint, const QStyleOption *option,
                const QWidget *widget,
                QStyleHintReturn *returnData) const override {
    if (hint == SH_Menu_FlashTriggeredItem)
      return 0;
    return QProxyStyle::styleHint(hint, option, widget, returnData);
  }
};
```

## Context Menu speed difference:
Below is an automated test opening a build of Porydaw based on upstream/main and deleting a note, undoing the deletion, and deleting it again, 50 times. Another run is done again, using the context menu changes. Notice how quicker the second run is.

https://github.com/user-attachments/assets/6b99d28a-99e0-4da3-b306-5fca65c884a7

Benchmarking is done on my M4 Pro Macbook Pro.

This change *also* lets the user quickly right-click another note without having to de-focus the note they selected first:

https://github.com/user-attachments/assets/189aa83f-3fa1-442c-a461-b0cc1ef39924


## Changes to `Songview:: drawGrid`
The second commit on this PR caches the derived colors that are used for the grid subdivisions once and batches up the Q.rect calls and then does the Qpen.paint in a nice pipeline.
The automated test shows only a ~3% difference, albeit consistent.

**Headless** benchmarks done by Codex using `QT_QPA_PLATFORM=offscreen` shows this makes `drawGrid` take 10% less time.

## With `gridLine` batching pipeline:

<img width="1723" height="1065" alt="Screenshot 2026-07-18 at 2 42 16 PM" src="https://github.com/user-attachments/assets/36b468e3-27d3-4f10-a3a1-84d2bda4c4de" />


### Without:

<img width="1723" height="1065" alt="Screenshot 2026-07-18 at 2 42 08 PM" src="https://github.com/user-attachments/assets/d0819105-6779-4ff2-9bb8-332da1946070" />


