### PR TITLE
Proposal for low-CPU playhead overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build-*/
 compile_commands.json
 CMakeUserPresets.json
 *.user
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,8 @@ qt_add_executable(porydaw
     src/tabcheck.cpp
     src/eventviewcheck.cpp
     src/rollcheck.cpp
+    src/rollcheckplayhead.cpp
+    src/rollcheckplayhead.h
     src/viewcheck.cpp
     src/roundtrip.cpp
     src/editcheck.cpp
@@ -127,6 +129,8 @@ qt_add_executable(porydaw
     src/ui/songviewmodel.h
     src/ui/songview.cpp
     src/ui/songview.h
+    src/ui/playheadoverlay.cpp
+    src/ui/playheadoverlay.h
     src/ui/eventlistview.cpp
     src/ui/eventlistview.h
     src/ui/viewsidecar.cpp

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -89,6 +89,7 @@ int main(int argc, char *argv[])
     const int selfTest = args.indexOf(QStringLiteral("--selftest"));
     if (selfTest >= 0 && selfTest + 2 < args.size()) {
         MainWindow window;
+        window.show();
         return window.runSelfTest(args[selfTest + 1], args[selfTest + 2]) ? 0 : 1;
     }
     const int saveCheck = args.indexOf(QStringLiteral("--savecheck"));

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -169,7 +169,7 @@ MainWindow::MainWindow(QWidget *parent)
     m_uiTimer = new QTimer(this);
     m_playheadTimer = new QTimer(this);
 
-    m_uiTimer->setInterval(100);
+    m_uiTimer->setInterval(33);
     connect(m_uiTimer, &QTimer::timeout, this, &MainWindow::uiTick);
     m_uiTimer->start();
     m_playheadTimer->setTimerType(Qt::PreciseTimer);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -173,6 +173,7 @@ MainWindow::MainWindow(QWidget *parent)
     connect(m_uiTimer, &QTimer::timeout, this, &MainWindow::uiTick);
     m_uiTimer->start();
     m_playheadTimer->setTimerType(Qt::PreciseTimer);
+    m_playheadTimer->setInterval(16);
     connect(m_playheadTimer, &QTimer::timeout, this, &MainWindow::synchronizePlayhead);
 
     updateTransportActions();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -173,7 +173,9 @@ MainWindow::MainWindow(QWidget *parent)
     connect(m_uiTimer, &QTimer::timeout, this, &MainWindow::uiTick);
     m_uiTimer->start();
     m_playheadTimer->setTimerType(Qt::PreciseTimer);
-    m_playheadTimer->setInterval(16);
+    // 60hz is 16.6 ms; Qt can tick faster than this, making the playhead move
+    // faster than 60hz and wasting time.
+    m_playheadTimer->setInterval(17);
     connect(m_playheadTimer, &QTimer::timeout, this, &MainWindow::synchronizePlayhead);
 
     updateTransportActions();
@@ -2288,8 +2290,11 @@ void MainWindow::uiTick()
 
 void MainWindow::synchronizePlayhead()
 {
-    if (!m_audioOk || !m_active || !m_audio.songLoaded())
+    if (!m_audioOk || !m_active || !m_audio.songLoaded()) {
+        // This also runs synchronously from activateSession(nullptr).
+        m_playheadTimer->stop();
         return;
+    }
 
     const bool playing = m_audio.transport() == Transport::Playing;
     m_active->view->setPlayheadSample(m_audio.playheadSamples(), playing);
@@ -2648,6 +2653,14 @@ bool MainWindow::runSelfTest(const QString &projectRoot, const QString &songLabe
             qInfo("selftest: sidecar view-state round trip OK");
         else
             qWarning("selftest: sidecar view-state round trip FAILED");
+    }
+    if (ok) {
+        destroySession(tab);
+        ok = !m_playheadTimer->isActive();
+        if (ok)
+            qInfo("selftest: closing final tab stopped playhead timer");
+        else
+            qWarning("selftest: closing final tab left playhead timer active");
     }
     stopPlayback();
     qInfo("selftest: %s", ok ? "PASS" : "FAIL");

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -32,6 +32,7 @@
 #include <QCloseEvent>
 
 #include <algorithm>
+#include <cmath>
 #include <cstring>
 
 #include "audio/sampleimport.h"
@@ -166,9 +167,13 @@ MainWindow::MainWindow(QWidget *parent)
                   : tr("No audio device."));
 
     m_uiTimer = new QTimer(this);
-    m_uiTimer->setInterval(33);
+    m_playheadTimer = new QTimer(this);
+
+    m_uiTimer->setInterval(100);
     connect(m_uiTimer, &QTimer::timeout, this, &MainWindow::uiTick);
     m_uiTimer->start();
+    m_playheadTimer->setTimerType(Qt::PreciseTimer);
+    connect(m_playheadTimer, &QTimer::timeout, this, &MainWindow::synchronizePlayhead);
 
     updateTransportActions();
 }
@@ -279,18 +284,18 @@ void MainWindow::buildUi()
     m_playPauseAction->setShortcut(Qt::Key_Space);
     connect(m_playPauseAction, &QAction::triggered, this, [this] {
         if (m_audio.transport() == Transport::Playing)
-            m_audio.pause();
+            pausePlayback();
         else
             startPlayback(/*fromEditCursor=*/true);
     });
     addAction(m_playPauseAction);
 
     m_pauseAction = new QAction(style()->standardIcon(QStyle::SP_MediaPause), tr("Pause"), this);
-    connect(m_pauseAction, &QAction::triggered, this, [this] { m_audio.pause(); });
+    connect(m_pauseAction, &QAction::triggered, this, [this] { pausePlayback(); });
     transport->addAction(m_pauseAction);
 
     m_stopAction = new QAction(style()->standardIcon(QStyle::SP_MediaStop), tr("Stop"), this);
-    connect(m_stopAction, &QAction::triggered, this, [this] { m_audio.stop(); });
+    connect(m_stopAction, &QAction::triggered, this, [this] { stopPlayback(); });
     transport->addAction(m_stopAction);
 
     m_loopAction = new QAction(style()->standardIcon(QStyle::SP_BrowserReload), tr("Loop"), this);
@@ -491,8 +496,10 @@ SongSession *MainWindow::createSession()
     // chasing controller state to the landing position.
     connect(s->view, &SongView::editCursorMoved, this, [this, s](uint64_t tick) {
         if (s == m_active && m_audioOk && m_audio.songLoaded()
-            && m_audio.transport() != Transport::Stopped)
+            && m_audio.transport() != Transport::Stopped) {
             m_audio.seek(m_audio.timeline()->sampleForTick(tick));
+            synchronizePlayhead();
+        }
     });
     connect(&s->doc, &SongDocument::documentChanged, this,
             [this, s] { onDocumentChanged(*s); });
@@ -581,6 +588,7 @@ void MainWindow::activateSession(SongSession *session, bool force)
         updateWindowTitle();
         updateTransportActions();
         persistOpenTabs();
+        synchronizePlayhead();
         return;
     }
 
@@ -591,6 +599,7 @@ void MainWindow::activateSession(SongSession *session, bool force)
         maybeRefreshVoicegroup(*session);
     if (m_audioOk)
         attachEngine(*session);
+    synchronizePlayhead();
     updateVoicegroupBrowser();
     updatePolyPanelContext(session);
 
@@ -1264,7 +1273,7 @@ void MainWindow::exportWav()
         return;
     appSettings.setValue(QStringLiteral("lastWavExportDir"), QFileInfo(path).path());
 
-    m_audio.stop();
+    stopPlayback();
 
     QProgressDialog progress(tr("Rendering %1...").arg(session->doc.label()),
                              tr("Cancel"), 0, 1000, this);
@@ -2252,14 +2261,11 @@ void MainWindow::uiTick()
 {
     if (!m_audioOk)
         return;
-
     if (m_active && m_audio.songLoaded()) {
         const uint64_t length = m_audio.timeline()->lengthSamples;
         m_timeLabel->setText(QStringLiteral("%1 / %2")
                                  .arg(formatTime(m_audio.playheadSamples()),
                                       formatTime(length)));
-        m_active->view->setPlayheadSample(m_audio.playheadSamples(),
-                                          m_audio.transport() == Transport::Playing);
 
         const uint64_t lost = m_audio.polyLostTotal();
         QString poly = tr("PCM %1/%2 · CGB %3/4")
@@ -2279,6 +2285,21 @@ void MainWindow::uiTick()
     updateTransportActions();
 }
 
+void MainWindow::synchronizePlayhead()
+{
+    if (!m_audioOk || !m_active || !m_audio.songLoaded())
+        return;
+
+    const bool playing = m_audio.transport() == Transport::Playing;
+    m_active->view->setPlayheadSample(m_audio.playheadSamples(), playing);
+    if (playing) {
+        if (!m_playheadTimer->isActive())
+            m_playheadTimer->start();
+    } else {
+        m_playheadTimer->stop();
+    }
+}
+
 void MainWindow::startPlayback(bool fromEditCursor)
 {
     if (!m_audioOk || !m_active || !m_audio.songLoaded())
@@ -2286,7 +2307,22 @@ void MainWindow::startPlayback(bool fromEditCursor)
     if (fromEditCursor || m_audio.transport() == Transport::Stopped)
         m_audio.seek(
             m_audio.timeline()->sampleForTick(m_active->view->editCursorTick()));
+   
+      
     m_audio.play();
+    synchronizePlayhead();
+}
+
+void MainWindow::pausePlayback()
+{
+    m_audio.pause();
+    synchronizePlayhead();
+}
+
+void MainWindow::stopPlayback()
+{
+    m_audio.stop();
+    synchronizePlayhead();
 }
 
 void MainWindow::updateTransportActions()
@@ -2336,7 +2372,7 @@ bool MainWindow::runSelfTest(const QString &projectRoot, const QString &songLabe
     qInfo("selftest: loaded %s (%zu events, %d tracks)", qUtf8Printable(target->label),
           m_audio.timeline()->events.size(), m_audio.timeline()->usedTrackCount);
 
-    m_audio.play();
+    startPlayback();
     QEventLoop loop;
     QTimer::singleShot(1500, &loop, &QEventLoop::quit);
     loop.exec();
@@ -2487,6 +2523,25 @@ bool MainWindow::runSelfTest(const QString &projectRoot, const QString &songLabe
 
     bool ok = m_audio.transport() == Transport::Playing && playedSeconds > 1.0
         && m_audio.playheadSamples() >= posBeforeEdit && vgEditOk;
+    if (ok) {
+        pausePlayback();
+        QTimer::singleShot(150, &loop, &QEventLoop::quit);
+        loop.exec();
+        const uint64_t pausedSample = m_audio.playheadSamples();
+        const double pausedViewTick = tab->view->playheadTick();
+        const double pausedEngineTick =
+            m_audio.timeline()->tickForSample(pausedSample);
+        constexpr double kPausedPlayheadToleranceTicks = 0.25;
+        ok = std::abs(pausedViewTick - pausedEngineTick) <= kPausedPlayheadToleranceTicks;
+        if (!ok) {
+            qWarning("selftest: paused playhead reconciliation FAILED "
+                     "(view %.3f ticks, engine %.3f ticks at %llu samples)",
+                     pausedViewTick, pausedEngineTick,
+                     static_cast<unsigned long long>(pausedSample));
+        }
+        startPlayback();
+    }
+
 
     // M2 polish: edit-cursor seek mid-playback, then play-from-cursor out of
     // Stopped (both go through AudioEngine::seek + chase). Loop disabled so
@@ -2501,7 +2556,7 @@ bool MainWindow::runSelfTest(const QString &projectRoot, const QString &songLabe
         QTimer::singleShot(300, &loop, &QEventLoop::quit);
         loop.exec();
         const uint64_t afterSeek = m_audio.playheadSamples();
-        m_audio.stop();
+        stopPlayback();
         QTimer::singleShot(200, &loop, &QEventLoop::quit);
         loop.exec();
         startPlayback(); // Stopped: must seek back to the edit cursor
@@ -2525,7 +2580,7 @@ bool MainWindow::runSelfTest(const QString &projectRoot, const QString &songLabe
         // playhead had ~300ms past the cursor before the pause; a 150ms
         // check after the restart must land back inside that window.
         if (ok) {
-            m_audio.pause();
+            pausePlayback();
             QTimer::singleShot(200, &loop, &QEventLoop::quit);
             loop.exec();
             const uint64_t pausedAt = m_audio.playheadSamples();
@@ -2593,7 +2648,7 @@ bool MainWindow::runSelfTest(const QString &projectRoot, const QString &songLabe
         else
             qWarning("selftest: sidecar view-state round trip FAILED");
     }
-    m_audio.stop();
+    stopPlayback();
     qInfo("selftest: %s", ok ? "PASS" : "FAIL");
     return ok;
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -192,10 +192,13 @@ private:
     // out of Paused — the Space binding (Reaper-style restart), while the
     // Play button resumes from the pause point.
     void startPlayback(bool fromEditCursor = false);
+    void pausePlayback();
+    void stopPlayback();
     // The session's cfg (volume/reverb) merged with the global engine knobs
     // — everything AudioEngine::updateSettings applies.
     SongSettings songSettingsFor(const SongSession &session) const;
     void updateTransportActions();
+    void synchronizePlayhead();
     void updateWindowTitle();
     QString formatTime(uint64_t samples) const;
 
@@ -261,4 +264,5 @@ private:
     QLabel *m_songLabel = nullptr;
     QLabel *m_polyLabel = nullptr;
     QTimer *m_uiTimer = nullptr;
+    QTimer *m_playheadTimer = nullptr;
 };

--- a/src/rollcheck.cpp
+++ b/src/rollcheck.cpp
@@ -18,6 +18,7 @@
 
 #include "core/songdocument.h"
 #include "project/decompproject.h"
+#include "rollcheckplayhead.h"
 #include "ui/songview.h"
 
 // --rollcheck <projectRoot> <song> [shot.png]: piano-roll gesture check.
@@ -556,6 +557,11 @@ int runRollCheck(const QString &projectRoot, const QString &songLabel,
         view.scrollByPx(view.contentX(0.0) - home); // back where it started
     }
 
+    // A stopped playhead is a thin child overlay. Moving it must preserve the
+    // timeline parents' backing stores instead of repainting their contents.
+    for (const QString &error : playheadOverlayCheckFailures(view, *timeline))
+        fail(qUtf8Printable(error));
+
     // Inline track rename: renameTrack opens a line editor on the header
     // row; Return commits (queued past the panel rebuild), Escape discards,
     // and loop-marker names are refused. isHidden (not isVisible) because
@@ -790,6 +796,9 @@ int runRollCheck(const QString &projectRoot, const QString &songLabel,
         }
     }
 
+    const auto screenshotTick =
+        uint64_t(std::ceil(std::max(0.0, view.tickAtContentX(view.width() / 2))));
+    view.setPlayheadSample(timeline->sampleForTick(screenshotTick), false);
     const QImage image = view.grab().toImage();
     if (image.isNull())
         fail("offscreen render produced no image");

--- a/src/rollcheckplayhead.cpp
+++ b/src/rollcheckplayhead.cpp
@@ -280,7 +280,10 @@ QStringList playheadOverlayCheckFailures(SongView &view,
           probe.clear();
           view.setPlayheadSample(secondSample, true);
           processPaints();
-          const int maxPlayheadExposureWidth = secondX - firstX + 16;
+          // Dirty strip: move delta + full glow diameter + full triangle width.
+          const int maxPlayheadExposureWidth =
+              secondX - firstX + 2 * songview::kPlayheadGlowRadius
+              + 2 * songview::kPlayheadTriangleHalfWidth;
           const bool overlayPaintedBroadly =
               probe.repaintedBroadly(marker, maxPlayheadExposureWidth);
           const bool anotherWidgetPaintedBroadly =
@@ -326,7 +329,8 @@ QStringList playheadOverlayCheckFailures(SongView &view,
                        playheadX > eventListArea.right()) {
               fail("could not map playhead into the event list");
             } else {
-              const int triangleHeight = std::min(9, eventListArea.height());
+              const int triangleHeight = std::min(
+                  songview::kPlayheadTriangleHeight + 1, eventListArea.height());
               const QRect triangleArea(eventListArea.left(), eventListArea.top(),
                                        eventListArea.width(), triangleHeight);
               const QRect eventListBody(eventListArea.left(),

--- a/src/rollcheckplayhead.cpp
+++ b/src/rollcheckplayhead.cpp
@@ -1,0 +1,388 @@
+#include "rollcheckplayhead.h"
+
+#include <QCoreApplication>
+#include <QEvent>
+#include <QObject>
+#include <QPaintEvent>
+#include <QRegion>
+#include <QWidget>
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+#include "core/miditimeline.h"
+#include "ui/eventlistview.h"
+#include "ui/playheadoverlay.h"
+#include "ui/songview.h"
+
+namespace
+{
+
+class PaintRegionProbe : public QObject
+{
+public:
+    void watch(QWidget *widget)
+    {
+        widget->installEventFilter(this);
+    }
+
+    void watchTree(QWidget *root)
+    {
+        watch(root);
+        for (QWidget *child : root->findChildren<QWidget *>())
+        {
+            watch(child);
+        }
+    }
+
+    void clear()
+    {
+        m_regions.clear();
+    }
+
+    bool repaintedAnyBroadly(const QWidget *allowed, int maxWidth) const
+    {
+        return std::any_of(
+            m_regions.cbegin(), m_regions.cend(),
+            [=](const DirtyRegion &region)
+            {
+                return region.widget != allowed
+                       && region.bounds.width() > maxWidth;
+            });
+    }
+
+    bool repaintedBroadly(const QWidget *widget, int maxWidth) const
+    {
+        return std::any_of(
+            m_regions.cbegin(), m_regions.cend(),
+            [=](const DirtyRegion &region)
+            {
+                return region.widget == widget
+                       && region.bounds.width() > maxWidth;
+            });
+    }
+
+private:
+    struct DirtyRegion
+    {
+        QWidget *widget;
+        QRect bounds;
+    };
+
+    bool eventFilter(QObject *watched, QEvent *event) override
+    {
+        if (event->type() == QEvent::Paint)
+        {
+            m_regions.push_back(
+                {static_cast<QWidget *>(watched),
+                 static_cast<QPaintEvent *>(event)->region().boundingRect()});
+        }
+        return QObject::eventFilter(watched, event);
+    }
+
+    std::vector<DirtyRegion> m_regions;
+};
+
+songview::PlayheadOverlay *findPlayheadOverlay(SongView &view)
+{
+    for (QWidget *widget : view.findChildren<QWidget *>())
+    {
+        if (auto *overlay = dynamic_cast<songview::PlayheadOverlay *>(widget))
+        {
+            return overlay;
+        }
+    }
+    return nullptr;
+}
+
+bool isPlayheadRed(const QColor &pixel, const QColor &playheadColor)
+{
+    const int colorDistance = std::abs(pixel.red() - playheadColor.red())
+                              + std::abs(pixel.green() - playheadColor.green())
+                              + std::abs(pixel.blue() - playheadColor.blue());
+    return colorDistance <= 12 && pixel.alpha() > 0;
+}
+
+bool isCompositedPlayheadRed(const QColor &pixel, const QColor &playheadColor)
+{
+    return isPlayheadRed(pixel, playheadColor)
+           || (pixel.red() - pixel.green() >= 24
+               && pixel.red() - pixel.blue() >= 24);
+}
+
+qreal playheadCenter(const QPixmap &pixmap, const QColor &playheadColor) {
+  const QImage image = pixmap.toImage();
+  const qreal devicePixelRatio = pixmap.devicePixelRatio();
+  qreal weightedX = 0.0;
+  qreal totalWeight = 0.0;
+  for (int x = 0; x < image.width(); ++x) {
+    for (int y = 0; y < image.height(); ++y) {
+      const QColor pixel = image.pixelColor(x, y);
+      if (isPlayheadRed(pixel, playheadColor) && pixel.alpha() > 80) {
+        weightedX += qreal(x) * pixel.alpha();
+        totalWeight += pixel.alpha();
+      }
+    }
+  }
+  return totalWeight > 0.0 ? weightedX / totalWeight / devicePixelRatio : -1.0;
+}
+
+bool hasPlayheadRedLine(const QImage &image, qreal devicePixelRatio,
+                        qreal logicalX, const QRect &logicalArea,
+                        const QColor &playheadColor)
+{
+    if (logicalArea.isEmpty())
+    {
+        return false;
+    }
+
+    const int left = std::max(
+        0, qFloor((logicalX - 1.0) * devicePixelRatio));
+    const int right = std::min(
+        image.width() - 1, qCeil((logicalX + 1.0) * devicePixelRatio));
+    const int top = std::max(0, qFloor(logicalArea.top() * devicePixelRatio));
+    const int bottom = std::min(
+        image.height() - 1,
+        qCeil((logicalArea.bottom() + 1) * devicePixelRatio) - 1);
+    for (int x = left; x <= right; ++x)
+    {
+        int consecutivePixels = 0;
+        for (int y = top; y <= bottom; ++y)
+        {
+            if (isCompositedPlayheadRed(image.pixelColor(x, y), playheadColor))
+            {
+                if (++consecutivePixels >= 3)
+                {
+                    return true;
+                }
+            }
+            else
+            {
+                consecutivePixels = 0;
+            }
+        }
+    }
+    return false;
+}
+
+void processPaints()
+{
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::UpdateRequest);
+    QCoreApplication::processEvents();
+}
+
+} // namespace
+
+QStringList playheadOverlayCheckFailures(SongView &view,
+                                         const MidiTimeline &timeline) {
+  QStringList failures;
+  auto fail = [&](const QString &message) { failures.append(message); };
+  const bool viewWasVisible = view.isVisible();
+  const bool viewHadDontShowOnScreen =
+      view.testAttribute(Qt::WA_DontShowOnScreen);
+  auto *marker = findPlayheadOverlay(view);
+  if (!marker) {
+    fail("unified playhead overlay not found");
+  } else {
+    if (!viewWasVisible) {
+      view.setAttribute(Qt::WA_DontShowOnScreen);
+      view.show();
+      processPaints();
+      (void)view.grab();
+      processPaints();
+    }
+    const int plotWidth = view.width() - songview::kGutterW;
+    if (plotWidth <= 64) {
+      fail("timeline plot is too narrow for the playhead check");
+    } else {
+      const auto tickAtContentX = [&](int x) {
+        return uint64_t(std::ceil(std::max(0.0, view.tickAtContentX(x))));
+      };
+      const uint64_t firstTick = tickAtContentX(plotWidth / 3);
+      const uint64_t secondTick = tickAtContentX(plotWidth / 3 + 12);
+      const int firstX = view.contentX(double(firstTick));
+      const int secondX = view.contentX(double(secondTick));
+      if (firstX < 0 || secondX >= plotWidth || secondX <= firstX ||
+          secondX - firstX > 32) {
+        fail("could not choose nearby visible playhead ticks");
+      } else {
+        QWidget *ruler = nullptr;
+        for (QWidget *child : view.findChildren<QWidget *>(
+                 QString(), Qt::FindDirectChildrenOnly)) {
+          const QRect childArea(child->mapTo(&view, QPoint()), child->size());
+          if (child != marker && child->isVisible() && childArea.top() == 0 &&
+              childArea.width() == view.width()) {
+            ruler = child;
+            break;
+          }
+        }
+        if (!ruler) {
+          fail("time ruler not found for the playhead check");
+        } else {
+          PaintRegionProbe probe;
+          probe.watchTree(&view);
+          const QColor playheadColor(226, 66, 66);
+          const auto expectedCenter = [&](uint64_t sample) {
+            const QPoint timelineOrigin =
+                ruler->mapTo(&view, QPoint(songview::kGutterW, 0));
+            return qreal(marker->mapFrom(&view, timelineOrigin).x()) +
+                   view.contentX(timeline.tickForSample(sample));
+          };
+          const auto checkCenter = [&](qreal center, uint64_t sample,
+                                       const QString &state) {
+            const qreal expected = expectedCenter(sample);
+            if (!marker->isVisible() || center < 0.0 ||
+                std::abs(center - expected) > 1.0) {
+              fail(QStringLiteral(
+                       "%1 playhead did not render at its expected position")
+                       .arg(state));
+            }
+          };
+          const uint64_t firstSample = timeline.sampleForTick(firstTick);
+          const uint64_t secondSample = timeline.sampleForTick(secondTick);
+          view.setPlayheadSample(firstSample, false);
+          processPaints();
+          const qreal firstMarkerCenter =
+              playheadCenter(marker->grab(), playheadColor);
+          checkCenter(firstMarkerCenter, firstSample,
+                      QStringLiteral("stopped"));
+          if (firstMarkerCenter >= 0.0) {
+            const QPixmap composedPixmap = view.grab();
+            const qreal playheadX =
+                marker->mapTo(&view, QPoint()).x() + firstMarkerCenter;
+            const QRect rulerArea(ruler->mapTo(&view, QPoint()), ruler->size());
+            if (hasPlayheadRedLine(composedPixmap.toImage(),
+                                   composedPixmap.devicePixelRatio(), playheadX,
+                                   rulerArea, playheadColor)) {
+              fail("playhead overpainted the time ruler");
+            }
+          }
+          view.setPlayheadSample(firstSample, true);
+          processPaints();
+          probe.clear();
+          view.setPlayheadSample(secondSample, true);
+          processPaints();
+          const int maxPlayheadExposureWidth = secondX - firstX + 16;
+          const bool overlayPaintedBroadly =
+              probe.repaintedBroadly(marker, maxPlayheadExposureWidth);
+          const bool anotherWidgetPaintedBroadly =
+              probe.repaintedAnyBroadly(marker, maxPlayheadExposureWidth);
+          const QPixmap playingPixmap = marker->grab();
+          const qreal playingMarkerCenter =
+              playheadCenter(playingPixmap, playheadColor);
+          checkCenter(playingMarkerCenter, secondSample,
+                      QStringLiteral("playing"));
+          if (overlayPaintedBroadly) {
+            fail("playhead move repainted the overlay broadly");
+          }
+          if (anotherWidgetPaintedBroadly) {
+            fail("playhead move repainted another timeline widget broadly");
+          }
+          view.setPlayheadSample(secondSample, false);
+          processPaints();
+          const QPixmap stoppedPixmap = marker->grab();
+          const qreal stoppedMarkerCenter =
+              playheadCenter(stoppedPixmap, playheadColor);
+          checkCenter(stoppedMarkerCenter, secondSample,
+                      QStringLiteral("stopped"));
+          if (playingPixmap.toImage() == stoppedPixmap.toImage()) {
+            fail("playing and stopped playheads rendered identically");
+          }
+          auto *events = view.findChild<EventListView *>();
+          if (!events) {
+            fail("EventListView child not found");
+          } else {
+            const qreal playheadX =
+                marker->mapTo(&view, QPoint()).x() + stoppedMarkerCenter;
+            view.setEventListVisible(true);
+            processPaints();
+            const QRect eventListArea =
+                QRect(events->mapTo(&view, QPoint()), events->size())
+                    .intersected(view.rect());
+            const QPixmap composedPixmap = view.grab();
+            const QImage composedImage = composedPixmap.toImage();
+            const qreal composedDpr = composedPixmap.devicePixelRatio();
+            if (!events->isVisible() || eventListArea.isEmpty()) {
+              fail("event list is not visible for the playhead check");
+            } else if (playheadX < eventListArea.left() ||
+                       playheadX > eventListArea.right()) {
+              fail("could not map playhead into the event list");
+            } else {
+              const bool overpaintedEventList =
+                  hasPlayheadRedLine(composedImage, composedDpr, playheadX,
+                                     eventListArea, playheadColor);
+              const QRect aboveEventList(0, 0, view.width(),
+                                         eventListArea.top());
+              const QRect belowEventList(
+                  0, eventListArea.bottom() + 1, view.width(),
+                  view.height() - eventListArea.bottom() - 1);
+              const bool renderedOnTimeline =
+                  hasPlayheadRedLine(composedImage, composedDpr, playheadX,
+                                     aboveEventList, playheadColor) ||
+                  hasPlayheadRedLine(composedImage, composedDpr, playheadX,
+                                     belowEventList, playheadColor);
+              if (overpaintedEventList) {
+                fail("playhead overpainted the event list");
+              }
+              if (!renderedOnTimeline) {
+                fail("playhead overlay did not render on visible timeline "
+                     "surfaces");
+              }
+            }
+          }
+          view.setEventListVisible(false);
+          processPaints();
+          uint64_t fractionalStartSample = timeline.sampleForTick(firstTick);
+          uint64_t fractionalEndSample = fractionalStartSample;
+          double playheadTick = timeline.tickForSample(fractionalStartSample);
+          int fractionalBucketX = view.contentX(playheadTick);
+          double fractionalStartX = playheadTick * view.pxPerTick();
+          const uint64_t fractionalSearchEnd =
+              timeline.sampleForTick(firstTick + 2);
+          for (uint64_t sample = fractionalStartSample + 1;
+               sample <= fractionalSearchEnd; ++sample) {
+            playheadTick = timeline.tickForSample(sample);
+            const int x = view.contentX(playheadTick);
+            const double exactX = playheadTick * view.pxPerTick();
+            if (x != fractionalBucketX) {
+              fractionalStartSample = sample;
+              fractionalBucketX = x;
+              fractionalStartX = exactX;
+            } else if (exactX - fractionalStartX >= 0.4) {
+              fractionalEndSample = sample;
+              break;
+            }
+          }
+          if (fractionalEndSample == fractionalStartSample) {
+            fail("could not choose fractional playhead positions");
+          } else {
+            view.setPlayheadSample(fractionalStartSample, true);
+            processPaints();
+            const qreal fractionalStart =
+                playheadCenter(marker->grab(), playheadColor);
+            view.setPlayheadSample(fractionalEndSample, true);
+            processPaints();
+            const qreal fractionalEnd =
+                playheadCenter(marker->grab(), playheadColor);
+            const qreal expectedDelta =
+                (timeline.tickForSample(fractionalEndSample) -
+                 timeline.tickForSample(fractionalStartSample)) *
+                view.pxPerTick();
+            if (std::abs((fractionalEnd - fractionalStart) - expectedDelta) >
+                0.2) {
+              fail("fractional playhead movement did not match its timeline "
+                   "position");
+            }
+          }
+        }
+      }
+    }
+  }
+  view.setPlayheadSample(0, false);
+  processPaints();
+  if (!viewWasVisible) {
+    view.hide();
+  }
+  view.setAttribute(Qt::WA_DontShowOnScreen, viewHadDontShowOnScreen);
+  return failures;
+}

--- a/src/rollcheckplayhead.cpp
+++ b/src/rollcheckplayhead.cpp
@@ -226,7 +226,7 @@ void checkEventListRendering(SongView &view,
     if (!hasLine(triangleArea)) {
         failures.append("playhead triangle did not render below the time ruler");
     }
-    if (redWidth(triangleArea.bottom()) <= redWidth(triangleArea.top())) {
+    if (redWidth(triangleArea.bottom() - 1) <= redWidth(triangleArea.top())) {
         failures.append("playhead triangle did not point up in the event list");
     }
     if (hasLine(QRect(eventListArea.left(),

--- a/src/rollcheckplayhead.cpp
+++ b/src/rollcheckplayhead.cpp
@@ -21,20 +21,6 @@ namespace
 class PaintRegionProbe : public QObject
 {
 public:
-    void watch(QWidget *widget)
-    {
-        widget->installEventFilter(this);
-    }
-
-    void watchTree(QWidget *root)
-    {
-        watch(root);
-        for (QWidget *child : root->findChildren<QWidget *>())
-        {
-            watch(child);
-        }
-    }
-
     void clear()
     {
         m_regions.clear();
@@ -85,12 +71,21 @@ private:
 
 songview::PlayheadOverlay *findPlayheadOverlay(SongView &view)
 {
-    for (QWidget *widget : view.findChildren<QWidget *>())
-    {
+    for (QWidget *widget : view.findChildren<QWidget *>()) {
         if (auto *overlay = dynamic_cast<songview::PlayheadOverlay *>(widget))
-        {
             return overlay;
-        }
+    }
+    return nullptr;
+}
+QWidget *findTimeRuler(SongView &view, const songview::PlayheadOverlay *overlay)
+{
+    for (QWidget *child : view.findChildren<QWidget *>(
+             QString(), Qt::FindDirectChildrenOnly))
+    {
+        const QRect childArea(child->mapTo(&view, QPoint()), child->size());
+        if (child != overlay && child->isVisible() && childArea.top() == 0
+            && childArea.width() == view.width())
+            return child;
     }
     return nullptr;
 }
@@ -189,246 +184,226 @@ void processPaints()
     QCoreApplication::processEvents();
 }
 
-} // namespace
-
-QStringList playheadOverlayCheckFailures(SongView &view,
-                                         const MidiTimeline &timeline) {
-  QStringList failures;
-  auto fail = [&](const QString &message) { failures.append(message); };
-  const bool viewWasVisible = view.isVisible();
-  const bool viewHadDontShowOnScreen =
-      view.testAttribute(Qt::WA_DontShowOnScreen);
-  auto *marker = findPlayheadOverlay(view);
-  if (!marker) {
-    fail("unified playhead overlay not found");
-  } else {
-    if (!viewWasVisible) {
-      view.setAttribute(Qt::WA_DontShowOnScreen);
-      view.show();
-      processPaints();
-      (void)view.grab();
-      processPaints();
+void checkEventListRendering(SongView &view,
+                             songview::PlayheadOverlay &marker,
+                             qreal stoppedMarkerCenter, const QRect &rulerArea,
+                             const QColor &playheadColor, QStringList &failures)
+{
+    auto *events = view.findChild<EventListView *>();
+    if (!events) {
+        failures.append("EventListView child not found");
+        return;
     }
+    const qreal playheadX = marker.mapTo(&view, QPoint()).x() + stoppedMarkerCenter;
+    view.setEventListVisible(true);
+    processPaints();
+    const QRect eventListArea =
+        QRect(events->mapTo(&view, QPoint()), events->size())
+            .intersected(view.rect());
+    const QPixmap composedPixmap = view.grab();
+    const QImage composedImage = composedPixmap.toImage();
+    const qreal composedDpr = composedPixmap.devicePixelRatio();
+    if (!events->isVisible() || eventListArea.isEmpty()) {
+        failures.append("event list is not visible for the playhead check");
+        return;
+    }
+    if (playheadX < eventListArea.left() || playheadX > eventListArea.right()) {
+        failures.append("could not map playhead into the event list");
+        return;
+    }
+    const int triangleHeight = std::min(songview::kPlayheadTriangleHeight + 1,
+                                        eventListArea.height());
+    const QRect triangleArea(eventListArea.left(), eventListArea.top(),
+                             eventListArea.width(), triangleHeight);
+    const auto hasLine = [&](const QRect &area) {
+        return hasPlayheadRedLine(composedImage, composedDpr, playheadX, area,
+                                  playheadColor);
+    };
+    const auto redWidth = [&](int y) {
+        return playheadRedWidth(composedImage, composedDpr, playheadX, y,
+                                playheadColor);
+    };
+    if (!hasLine(triangleArea)) {
+        failures.append("playhead triangle did not render below the time ruler");
+    }
+    if (redWidth(triangleArea.bottom()) <= redWidth(triangleArea.top())) {
+        failures.append("playhead triangle did not point up in the event list");
+    }
+    if (hasLine(QRect(eventListArea.left(),
+                      eventListArea.top() + triangleHeight,
+                      eventListArea.width(),
+                      eventListArea.height() - triangleHeight))) {
+        failures.append("playhead line overpainted the event list");
+    }
+    if (hasLine(rulerArea)) {
+        failures.append("playhead rendered in the event-list time ruler");
+    }
+    if (!hasLine(QRect(0, 0, view.width(), eventListArea.top()))
+        && !hasLine(QRect(0, eventListArea.bottom() + 1, view.width(),
+                          view.height() - eventListArea.bottom() - 1))) {
+        failures.append("playhead overlay did not render on visible timeline "
+                        "surfaces");
+    }
+}
+
+void checkFractionalMovement(SongView &view, const MidiTimeline &timeline,
+                             songview::PlayheadOverlay &marker,
+                             const QColor &playheadColor, uint64_t firstTick,
+                             QStringList &failures) {
+    uint64_t fractionalStartSample = timeline.sampleForTick(firstTick);
+    uint64_t fractionalEndSample = fractionalStartSample;
+    double playheadTick = timeline.tickForSample(fractionalStartSample);
+    int fractionalBucketX = view.contentX(playheadTick);
+    double fractionalStartX = playheadTick * view.pxPerTick();
+    const uint64_t fractionalSearchEnd = timeline.sampleForTick(firstTick + 2);
+    for (uint64_t sample = fractionalStartSample + 1;
+         sample <= fractionalSearchEnd; ++sample) {
+        playheadTick = timeline.tickForSample(sample);
+        const int x = view.contentX(playheadTick);
+        const double exactX = playheadTick * view.pxPerTick();
+        if (x != fractionalBucketX) {
+            fractionalStartSample = sample;
+            fractionalBucketX = x;
+            fractionalStartX = exactX;
+        } else if (exactX - fractionalStartX >= 0.4) {
+            fractionalEndSample = sample;
+            break;
+        }
+    }
+    if (fractionalEndSample == fractionalStartSample) {
+        failures.append("could not choose fractional playhead positions");
+        return;
+    }
+    view.setPlayheadSample(fractionalStartSample, true);
+    processPaints();
+    const qreal fractionalStart = playheadCenter(marker.grab(), playheadColor);
+    view.setPlayheadSample(fractionalEndSample, true);
+    processPaints();
+    const qreal fractionalEnd = playheadCenter(marker.grab(), playheadColor);
+    const qreal expectedDelta =
+        (timeline.tickForSample(fractionalEndSample)
+         - timeline.tickForSample(fractionalStartSample)) * view.pxPerTick();
+    if (std::abs((fractionalEnd - fractionalStart) - expectedDelta) > 0.2) {
+        failures.append("fractional playhead movement did not match its timeline "
+                        "position");
+    }
+}
+
+void checkPlayheadRendering(SongView &view, const MidiTimeline &timeline,
+                            songview::PlayheadOverlay &marker, QStringList &failures) {
     const int plotWidth = view.width() - songview::kGutterW;
     if (plotWidth <= 64) {
-      fail("timeline plot is too narrow for the playhead check");
-    } else {
-      const auto tickAtContentX = [&](int x) {
-        return uint64_t(std::ceil(std::max(0.0, view.tickAtContentX(x))));
-      };
-      const uint64_t firstTick = tickAtContentX(plotWidth / 3);
-      const uint64_t secondTick = tickAtContentX(plotWidth / 3 + 12);
-      const int firstX = view.contentX(double(firstTick));
-      const int secondX = view.contentX(double(secondTick));
-      if (firstX < 0 || secondX >= plotWidth || secondX <= firstX ||
-          secondX - firstX > 32) {
-        fail("could not choose nearby visible playhead ticks");
-      } else {
-        QWidget *ruler = nullptr;
-        for (QWidget *child : view.findChildren<QWidget *>(
-                 QString(), Qt::FindDirectChildrenOnly)) {
-          const QRect childArea(child->mapTo(&view, QPoint()), child->size());
-          if (child != marker && child->isVisible() && childArea.top() == 0 &&
-              childArea.width() == view.width()) {
-            ruler = child;
-            break;
-          }
-        }
-        if (!ruler) {
-          fail("time ruler not found for the playhead check");
-        } else {
-          PaintRegionProbe probe;
-          probe.watchTree(&view);
-          const QColor playheadColor(226, 66, 66);
-          const auto expectedCenter = [&](uint64_t sample) {
-            const QPoint timelineOrigin =
-                ruler->mapTo(&view, QPoint(songview::kGutterW, 0));
-            return qreal(marker->mapFrom(&view, timelineOrigin).x()) +
-                   view.contentX(timeline.tickForSample(sample));
-          };
-          const auto checkCenter = [&](qreal center, uint64_t sample,
-                                       const QString &state) {
-            const qreal expected = expectedCenter(sample);
-            if (!marker->isVisible() || center < 0.0 ||
-                std::abs(center - expected) > 1.0) {
-              fail(QStringLiteral(
-                       "%1 playhead did not render at its expected position")
-                       .arg(state));
-            }
-          };
-          const uint64_t firstSample = timeline.sampleForTick(firstTick);
-          const uint64_t secondSample = timeline.sampleForTick(secondTick);
-          view.setPlayheadSample(firstSample, false);
-          processPaints();
-          const qreal firstMarkerCenter =
-              playheadCenter(marker->grab(), playheadColor);
-          checkCenter(firstMarkerCenter, firstSample,
-                      QStringLiteral("stopped"));
-          const QRect rulerArea(ruler->mapTo(&view, QPoint()), ruler->size());
-          if (firstMarkerCenter >= 0.0) {
-            const QPixmap composedPixmap = view.grab();
-            const qreal playheadX =
-                marker->mapTo(&view, QPoint()).x() + firstMarkerCenter;
-            if (hasPlayheadRedLine(composedPixmap.toImage(),
-                                   composedPixmap.devicePixelRatio(), playheadX,
-                                   rulerArea, playheadColor)) {
-              fail("playhead rendered in the time ruler");
-            }
-          }
-          view.setPlayheadSample(firstSample, true);
-          processPaints();
-          probe.clear();
-          view.setPlayheadSample(secondSample, true);
-          processPaints();
-          // Dirty strip: move delta + full glow diameter + full triangle width.
-          const int maxPlayheadExposureWidth =
-              secondX - firstX + 2 * songview::kPlayheadGlowRadius
-              + 2 * songview::kPlayheadTriangleHalfWidth;
-          const bool overlayPaintedBroadly =
-              probe.repaintedBroadly(marker, maxPlayheadExposureWidth);
-          const bool anotherWidgetPaintedBroadly =
-              probe.repaintedAnyBroadly(marker, maxPlayheadExposureWidth);
-          const QPixmap playingPixmap = marker->grab();
-          const qreal playingMarkerCenter =
-              playheadCenter(playingPixmap, playheadColor);
-          checkCenter(playingMarkerCenter, secondSample,
-                      QStringLiteral("playing"));
-          if (overlayPaintedBroadly) {
-            fail("playhead move repainted the overlay broadly");
-          }
-          if (anotherWidgetPaintedBroadly) {
-            fail("playhead move repainted another timeline widget broadly");
-          }
-          view.setPlayheadSample(secondSample, false);
-          processPaints();
-          const QPixmap stoppedPixmap = marker->grab();
-          const qreal stoppedMarkerCenter =
-              playheadCenter(stoppedPixmap, playheadColor);
-          checkCenter(stoppedMarkerCenter, secondSample,
-                      QStringLiteral("stopped"));
-          if (playingPixmap.toImage() == stoppedPixmap.toImage()) {
-            fail("playing and stopped playheads rendered identically");
-          }
-          auto *events = view.findChild<EventListView *>();
-          if (!events) {
-            fail("EventListView child not found");
-          } else {
-            const qreal playheadX =
-                marker->mapTo(&view, QPoint()).x() + stoppedMarkerCenter;
-            view.setEventListVisible(true);
-            processPaints();
-            const QRect eventListArea =
-                QRect(events->mapTo(&view, QPoint()), events->size())
-                    .intersected(view.rect());
-            const QPixmap composedPixmap = view.grab();
-            const QImage composedImage = composedPixmap.toImage();
-            const qreal composedDpr = composedPixmap.devicePixelRatio();
-            if (!events->isVisible() || eventListArea.isEmpty()) {
-              fail("event list is not visible for the playhead check");
-            } else if (playheadX < eventListArea.left() ||
-                       playheadX > eventListArea.right()) {
-              fail("could not map playhead into the event list");
-            } else {
-              const int triangleHeight = std::min(
-                  songview::kPlayheadTriangleHeight + 1, eventListArea.height());
-              const QRect triangleArea(eventListArea.left(), eventListArea.top(),
-                                       eventListArea.width(), triangleHeight);
-              const QRect eventListBody(eventListArea.left(),
-                                        eventListArea.top() + triangleHeight,
-                                        eventListArea.width(),
-                                        eventListArea.height() - triangleHeight);
-              const bool overpaintedEventList =
-                  hasPlayheadRedLine(composedImage, composedDpr, playheadX,
-                                     eventListBody, playheadColor);
-              const QRect aboveEventList(0, 0, view.width(),
-                                         eventListArea.top());
-              const QRect belowEventList(
-                  0, eventListArea.bottom() + 1, view.width(),
-                  view.height() - eventListArea.bottom() - 1);
-              const bool renderedOnTimeline =
-                  hasPlayheadRedLine(composedImage, composedDpr, playheadX,
-                                     aboveEventList, playheadColor) ||
-                  hasPlayheadRedLine(composedImage, composedDpr, playheadX,
-                                     belowEventList, playheadColor);
-              if (!hasPlayheadRedLine(composedImage, composedDpr, playheadX,
-                                      triangleArea, playheadColor)) {
-                fail("playhead triangle did not render below the time ruler");
-              }
-              const int triangleTopWidth =
-                  playheadRedWidth(composedImage, composedDpr, playheadX,
-                                   triangleArea.top(), playheadColor);
-              const int triangleBottomWidth =
-                  playheadRedWidth(composedImage, composedDpr, playheadX,
-                                   triangleArea.bottom(), playheadColor);
-              if (triangleBottomWidth <= triangleTopWidth) {
-                fail("playhead triangle did not point up in the event list");
-              }
-              if (overpaintedEventList) {
-                fail("playhead line overpainted the event list");
-              }
-              if (hasPlayheadRedLine(composedImage, composedDpr, playheadX,
-                                     rulerArea, playheadColor)) {
-                fail("playhead rendered in the event-list time ruler");
-              }
-              if (!renderedOnTimeline) {
-                fail("playhead overlay did not render on visible timeline "
-                     "surfaces");
-              }
-            }
-          }
-          view.setEventListVisible(false);
-          processPaints();
-          uint64_t fractionalStartSample = timeline.sampleForTick(firstTick);
-          uint64_t fractionalEndSample = fractionalStartSample;
-          double playheadTick = timeline.tickForSample(fractionalStartSample);
-          int fractionalBucketX = view.contentX(playheadTick);
-          double fractionalStartX = playheadTick * view.pxPerTick();
-          const uint64_t fractionalSearchEnd =
-              timeline.sampleForTick(firstTick + 2);
-          for (uint64_t sample = fractionalStartSample + 1;
-               sample <= fractionalSearchEnd; ++sample) {
-            playheadTick = timeline.tickForSample(sample);
-            const int x = view.contentX(playheadTick);
-            const double exactX = playheadTick * view.pxPerTick();
-            if (x != fractionalBucketX) {
-              fractionalStartSample = sample;
-              fractionalBucketX = x;
-              fractionalStartX = exactX;
-            } else if (exactX - fractionalStartX >= 0.4) {
-              fractionalEndSample = sample;
-              break;
-            }
-          }
-          if (fractionalEndSample == fractionalStartSample) {
-            fail("could not choose fractional playhead positions");
-          } else {
-            view.setPlayheadSample(fractionalStartSample, true);
-            processPaints();
-            const qreal fractionalStart =
-                playheadCenter(marker->grab(), playheadColor);
-            view.setPlayheadSample(fractionalEndSample, true);
-            processPaints();
-            const qreal fractionalEnd =
-                playheadCenter(marker->grab(), playheadColor);
-            const qreal expectedDelta =
-                (timeline.tickForSample(fractionalEndSample) -
-                 timeline.tickForSample(fractionalStartSample)) *
-                view.pxPerTick();
-            if (std::abs((fractionalEnd - fractionalStart) - expectedDelta) >
-                0.2) {
-              fail("fractional playhead movement did not match its timeline "
-                   "position");
-            }
-          }
-        }
-      }
+        failures.append("timeline plot is too narrow for the playhead check");
+        return;
     }
-  }
-  view.setPlayheadSample(0, false);
-  processPaints();
-  if (!viewWasVisible) {
-    view.hide();
-  }
-  view.setAttribute(Qt::WA_DontShowOnScreen, viewHadDontShowOnScreen);
-  return failures;
+    const auto tickAtContentX = [&view](int x) {
+        return uint64_t(std::ceil(std::max(0.0, view.tickAtContentX(x))));
+    };
+    const uint64_t firstTick = tickAtContentX(plotWidth / 3);
+    const uint64_t secondTick = tickAtContentX(plotWidth / 3 + 12);
+    const int firstX = view.contentX(double(firstTick));
+    const int secondX = view.contentX(double(secondTick));
+    if (firstX < 0 || secondX >= plotWidth || secondX <= firstX
+        || secondX - firstX > 32) {
+        failures.append("could not choose nearby visible playhead ticks");
+        return;
+    }
+    QWidget *ruler = findTimeRuler(view, &marker);
+    if (!ruler) {
+        failures.append("time ruler not found for the playhead check");
+        return;
+    }
+    PaintRegionProbe probe;
+    view.installEventFilter(&probe);
+    for (QWidget *child : view.findChildren<QWidget *>())
+        child->installEventFilter(&probe);
+    const QColor playheadColor(226, 66, 66);
+    const auto expectedCenter = [&](uint64_t sample) {
+        const QPoint timelineOrigin = ruler->mapTo(&view, QPoint(songview::kGutterW, 0));
+        return qreal(marker.mapFrom(&view, timelineOrigin).x())
+               + view.contentX(timeline.tickForSample(sample));
+    };
+    const auto checkCenter = [&](qreal center, uint64_t sample,
+                                 const QString &state) {
+        const qreal expected = expectedCenter(sample);
+        if (!marker.isVisible() || center < 0.0
+            || std::abs(center - expected) > 1.0) {
+            failures.append(
+                QStringLiteral("%1 playhead did not render at its expected position")
+                    .arg(state));
+        }
+    };
+    const uint64_t firstSample = timeline.sampleForTick(firstTick);
+    const uint64_t secondSample = timeline.sampleForTick(secondTick);
+    view.setPlayheadSample(firstSample, false);
+    processPaints();
+    const qreal firstMarkerCenter = playheadCenter(marker.grab(), playheadColor);
+    checkCenter(firstMarkerCenter, firstSample, QStringLiteral("stopped"));
+    const QRect rulerArea(ruler->mapTo(&view, QPoint()), ruler->size());
+    if (firstMarkerCenter >= 0.0) {
+        const QPixmap composedPixmap = view.grab();
+        const qreal playheadX = marker.mapTo(&view, QPoint()).x() + firstMarkerCenter;
+        if (hasPlayheadRedLine(composedPixmap.toImage(),
+                               composedPixmap.devicePixelRatio(), playheadX,
+                               rulerArea, playheadColor)) {
+            failures.append("playhead rendered in the time ruler");
+        }
+    }
+    view.setPlayheadSample(firstSample, true);
+    processPaints();
+    probe.clear();
+    view.setPlayheadSample(secondSample, true);
+    processPaints();
+    // Dirty strip: move delta + full glow diameter + full triangle width.
+    const int maxPlayheadExposureWidth =
+        secondX - firstX + 2 * songview::kPlayheadGlowRadius
+        + 2 * songview::kPlayheadTriangleHalfWidth;
+    const bool overlayPaintedBroadly = probe.repaintedBroadly(&marker, maxPlayheadExposureWidth);
+    const bool anotherWidgetPaintedBroadly = probe.repaintedAnyBroadly(&marker, maxPlayheadExposureWidth);
+    const QPixmap playingPixmap = marker.grab();
+    const qreal playingMarkerCenter = playheadCenter(playingPixmap, playheadColor);
+    checkCenter(playingMarkerCenter, secondSample, QStringLiteral("playing"));
+    if (overlayPaintedBroadly)
+        failures.append("playhead move repainted the overlay broadly");
+    if (anotherWidgetPaintedBroadly)
+        failures.append("playhead move repainted another timeline widget broadly");
+    view.setPlayheadSample(secondSample, false);
+    processPaints();
+    const QPixmap stoppedPixmap = marker.grab();
+    const qreal stoppedMarkerCenter = playheadCenter(stoppedPixmap, playheadColor);
+    checkCenter(stoppedMarkerCenter, secondSample, QStringLiteral("stopped"));
+    if (playingPixmap.toImage() == stoppedPixmap.toImage())
+        failures.append("playing and stopped playheads rendered identically");
+    checkEventListRendering(view, marker, stoppedMarkerCenter, rulerArea,
+                            playheadColor, failures);
+    view.setEventListVisible(false);
+    processPaints();
+    checkFractionalMovement(view, timeline, marker, playheadColor, firstTick,
+                            failures);
+}
+
+} // namespace
+
+QStringList playheadOverlayCheckFailures(SongView &view, const MidiTimeline &timeline) {
+    QStringList failures;
+    const bool viewWasVisible = view.isVisible();
+    const bool viewHadDontShowOnScreen = view.testAttribute(Qt::WA_DontShowOnScreen);
+    if (auto *marker = findPlayheadOverlay(view)) {
+        if (!viewWasVisible) {
+            view.setAttribute(Qt::WA_DontShowOnScreen);
+            view.show();
+            processPaints();
+            (void)view.grab();
+            processPaints();
+        }
+        checkPlayheadRendering(view, timeline, *marker, failures);
+    } else {
+        failures.append("unified playhead overlay not found");
+    }
+    view.setPlayheadSample(0, false);
+    processPaints();
+    if (!viewWasVisible)
+        view.hide();
+    view.setAttribute(Qt::WA_DontShowOnScreen, viewHadDontShowOnScreen);
+    return failures;
 }

--- a/src/rollcheckplayhead.cpp
+++ b/src/rollcheckplayhead.cpp
@@ -165,6 +165,24 @@ bool hasPlayheadRedLine(const QImage &image, qreal devicePixelRatio,
     return false;
 }
 
+int playheadRedWidth(const QImage &image, qreal devicePixelRatio,
+                     qreal logicalX, int logicalY,
+                     const QColor &playheadColor)
+{
+    const int left = std::max(
+        0, qFloor((logicalX - 4.0) * devicePixelRatio));
+    const int right = std::min(
+        image.width() - 1, qCeil((logicalX + 4.0) * devicePixelRatio));
+    const int y = std::clamp(qRound(logicalY * devicePixelRatio),
+                             0, image.height() - 1);
+    int width = 0;
+    for (int x = left; x <= right; ++x) {
+        if (isCompositedPlayheadRed(image.pixelColor(x, y), playheadColor))
+            ++width;
+    }
+    return width;
+}
+
 void processPaints()
 {
     QCoreApplication::sendPostedEvents(nullptr, QEvent::UpdateRequest);
@@ -254,7 +272,7 @@ QStringList playheadOverlayCheckFailures(SongView &view,
             if (hasPlayheadRedLine(composedPixmap.toImage(),
                                    composedPixmap.devicePixelRatio(), playheadX,
                                    rulerArea, playheadColor)) {
-              fail("playhead overpainted the time ruler");
+              fail("playhead rendered in the time ruler");
             }
           }
           view.setPlayheadSample(firstSample, true);
@@ -308,9 +326,16 @@ QStringList playheadOverlayCheckFailures(SongView &view,
                        playheadX > eventListArea.right()) {
               fail("could not map playhead into the event list");
             } else {
+              const int triangleHeight = std::min(9, eventListArea.height());
+              const QRect triangleArea(eventListArea.left(), eventListArea.top(),
+                                       eventListArea.width(), triangleHeight);
+              const QRect eventListBody(eventListArea.left(),
+                                        eventListArea.top() + triangleHeight,
+                                        eventListArea.width(),
+                                        eventListArea.height() - triangleHeight);
               const bool overpaintedEventList =
                   hasPlayheadRedLine(composedImage, composedDpr, playheadX,
-                                     eventListArea, playheadColor);
+                                     eventListBody, playheadColor);
               const QRect aboveEventList(0, 0, view.width(),
                                          eventListArea.top());
               const QRect belowEventList(
@@ -321,12 +346,25 @@ QStringList playheadOverlayCheckFailures(SongView &view,
                                      aboveEventList, playheadColor) ||
                   hasPlayheadRedLine(composedImage, composedDpr, playheadX,
                                      belowEventList, playheadColor);
-              if (overpaintedEventList) {
-                fail("playhead overpainted the event list");
-              }
               if (!hasPlayheadRedLine(composedImage, composedDpr, playheadX,
-                                      rulerArea, playheadColor)) {
-                fail("playhead did not extend into the event-list time ruler");
+                                      triangleArea, playheadColor)) {
+                fail("playhead triangle did not render below the time ruler");
+              }
+              const int triangleTopWidth =
+                  playheadRedWidth(composedImage, composedDpr, playheadX,
+                                   triangleArea.top(), playheadColor);
+              const int triangleBottomWidth =
+                  playheadRedWidth(composedImage, composedDpr, playheadX,
+                                   triangleArea.bottom(), playheadColor);
+              if (triangleBottomWidth <= triangleTopWidth) {
+                fail("playhead triangle did not point up in the event list");
+              }
+              if (overpaintedEventList) {
+                fail("playhead line overpainted the event list");
+              }
+              if (hasPlayheadRedLine(composedImage, composedDpr, playheadX,
+                                     rulerArea, playheadColor)) {
+                fail("playhead rendered in the event-list time ruler");
               }
               if (!renderedOnTimeline) {
                 fail("playhead overlay did not render on visible timeline "

--- a/src/rollcheckplayhead.cpp
+++ b/src/rollcheckplayhead.cpp
@@ -246,11 +246,11 @@ QStringList playheadOverlayCheckFailures(SongView &view,
               playheadCenter(marker->grab(), playheadColor);
           checkCenter(firstMarkerCenter, firstSample,
                       QStringLiteral("stopped"));
+          const QRect rulerArea(ruler->mapTo(&view, QPoint()), ruler->size());
           if (firstMarkerCenter >= 0.0) {
             const QPixmap composedPixmap = view.grab();
             const qreal playheadX =
                 marker->mapTo(&view, QPoint()).x() + firstMarkerCenter;
-            const QRect rulerArea(ruler->mapTo(&view, QPoint()), ruler->size());
             if (hasPlayheadRedLine(composedPixmap.toImage(),
                                    composedPixmap.devicePixelRatio(), playheadX,
                                    rulerArea, playheadColor)) {
@@ -323,6 +323,10 @@ QStringList playheadOverlayCheckFailures(SongView &view,
                                      belowEventList, playheadColor);
               if (overpaintedEventList) {
                 fail("playhead overpainted the event list");
+              }
+              if (!hasPlayheadRedLine(composedImage, composedDpr, playheadX,
+                                      rulerArea, playheadColor)) {
+                fail("playhead did not extend into the event-list time ruler");
               }
               if (!renderedOnTimeline) {
                 fail("playhead overlay did not render on visible timeline "

--- a/src/rollcheckplayhead.h
+++ b/src/rollcheckplayhead.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <QStringList>
+
+class MidiTimeline;
+class SongView;
+
+QStringList playheadOverlayCheckFailures(SongView &view, const MidiTimeline &timeline);

--- a/src/ui/playheadoverlay.cpp
+++ b/src/ui/playheadoverlay.cpp
@@ -186,11 +186,17 @@ void PlayheadOverlay::synchronizeGeometry()
     Q_ASSERT(owner);
 
     const QRegion oldVisibleSurfaceRegion = m_visibleSurfaceRegion;
+    const bool eventListVisible = !m_surfaces.roll->isVisibleTo(owner);
     const QRect rollGeometry = surfaceGeometry(m_surfaces.roll);
-    const QRect playheadGeometry(0, rollGeometry.top(), owner->width(),
-                                 owner->height() - rollGeometry.top());
+    const QRect topGeometry =
+        eventListVisible ? surfaceGeometry(m_surfaces.ruler) : rollGeometry;
+    const QRect playheadGeometry(0, topGeometry.top(), owner->width(),
+                                 owner->height() - topGeometry.top());
     const QRegion visibleSurfaces =
-        visibleSurfaceRegion(m_surfaces.roll, m_surfaces.rollOrigin)
+        (eventListVisible
+             ? visibleSurfaceRegion(m_surfaces.ruler, m_surfaces.rulerOrigin)
+             : QRegion())
+        + visibleSurfaceRegion(m_surfaces.roll, m_surfaces.rollOrigin)
         + visibleSurfaceRegion(m_surfaces.lanes, m_surfaces.lanesOrigin)
         + visibleSurfaceRegion(m_surfaces.strip, m_surfaces.stripOrigin);
     const int timelineOrigin =

--- a/src/ui/playheadoverlay.cpp
+++ b/src/ui/playheadoverlay.cpp
@@ -1,0 +1,218 @@
+#include "playheadoverlay.h"
+
+#include <QEvent>
+#include <QLinearGradient>
+#include <QPainter>
+#include <QPainterPath>
+#include <QPen>
+
+namespace songview {
+
+namespace {
+
+constexpr int kGlowWidth = 7;
+constexpr int kPlayheadHalfWidth = kGlowWidth;
+constexpr int kLineWidth = 1;
+
+} // namespace
+
+PlayheadOverlay::PlayheadOverlay(QWidget *owner, const Surfaces &surfaces,
+                                 const QColor &color)
+    : QWidget(owner)
+    , m_surfaces(surfaces)
+    , m_color(color)
+{
+    Q_ASSERT(owner);
+    Q_ASSERT(m_surfaces.ruler);
+    Q_ASSERT(m_surfaces.roll);
+    Q_ASSERT(m_surfaces.lanes);
+    Q_ASSERT(m_surfaces.strip);
+
+    QColor transparent = color;
+    transparent.setAlpha(0);
+    QColor stoppedGlowColor = color;
+    stoppedGlowColor.setAlphaF(color.alphaF() * 0.2);
+    QColor playingGlowColor = color;
+    playingGlowColor.setAlphaF(color.alphaF() * 0.3);
+    QColor glowAt15Percent = playingGlowColor;
+    glowAt15Percent.setAlphaF(playingGlowColor.alphaF() * 0.15);
+    QColor glowAt75Percent = playingGlowColor;
+    glowAt75Percent.setAlphaF(playingGlowColor.alphaF() * 0.75);
+    QLinearGradient playingGlow(0, 0, kGlowWidth, 0);
+    playingGlow.setColorAt(0, transparent);
+    playingGlow.setColorAt(0.5, glowAt15Percent);
+    playingGlow.setColorAt(0.75, glowAt75Percent);
+    playingGlow.setColorAt(1.0 - 1.0 / kGlowWidth, playingGlowColor);
+    m_playingGlow = QBrush(playingGlow);
+    QLinearGradient stoppedGlow(0, 0, kGlowWidth, 0);
+    stoppedGlow.setColorAt(0, transparent);
+    stoppedGlow.setColorAt(0.5, stoppedGlowColor);
+    stoppedGlow.setColorAt(0.65, transparent);
+    m_stoppedGlow = QBrush(stoppedGlow);
+
+    setAttribute(Qt::WA_TransparentForMouseEvents);
+    setAttribute(Qt::WA_NoSystemBackground);
+
+    const auto observeSurfaceGeometry = [this, owner](QWidget *surface) {
+        for (QWidget *widget = surface; widget; widget = widget->parentWidget()) {
+            widget->installEventFilter(this);
+            if (widget == owner)
+                break;
+        }
+    };
+    observeSurfaceGeometry(m_surfaces.ruler);
+    observeSurfaceGeometry(m_surfaces.roll);
+    observeSurfaceGeometry(m_surfaces.lanes);
+    observeSurfaceGeometry(m_surfaces.strip);
+
+    synchronizeGeometry();
+    show();
+}
+
+void PlayheadOverlay::setPlayhead(qreal contentX, bool visible, bool playing)
+{
+    const qreal oldX = m_playheadX;
+    const bool oldVisible = m_visible;
+    const bool oldPlaying = m_playing;
+
+    m_playheadContentX = contentX;
+    m_playheadX = qreal(m_timelineOrigin) + contentX;
+    m_visible = visible;
+    m_playing = playing;
+
+    if (oldX == m_playheadX && oldVisible == m_visible && oldPlaying == m_playing)
+        return;
+
+    QRegion dirty;
+    if (oldVisible)
+        dirty += playheadRegion(oldX);
+    if (m_visible)
+        dirty += playheadRegion(m_playheadX);
+    if (!dirty.isEmpty())
+        update(dirty);
+}
+
+bool PlayheadOverlay::eventFilter(QObject *, QEvent *event)
+{
+    switch (event->type()) {
+    case QEvent::Move:
+    case QEvent::Resize:
+    case QEvent::Show:
+    case QEvent::Hide:
+    case QEvent::LayoutRequest:
+        synchronizeGeometry();
+        break;
+    default:
+        break;
+    }
+    return false;
+}
+
+void PlayheadOverlay::paintEvent(QPaintEvent *)
+{
+    if (!m_visible || m_visibleSurfaceRegion.isEmpty()
+        || m_playheadGeometry.isEmpty())
+        return;
+
+    QPainter painter(this);
+    painter.setClipRegion(m_visibleSurfaceRegion);
+    painter.setRenderHint(QPainter::Antialiasing);
+
+    const int playheadTop = m_playheadGeometry.top();
+    const qreal glowOffset = m_playing ? kGlowWidth : kGlowWidth / 2.0;
+    const qreal glowStartX = m_playheadX - glowOffset;
+    const QBrush &glow = m_playing ? m_playingGlow : m_stoppedGlow;
+    painter.save();
+    painter.translate(glowStartX, playheadTop);
+    painter.fillRect(0, 0, kGlowWidth, m_playheadGeometry.height(), glow);
+    painter.restore();
+
+    painter.setPen(QPen(m_color, kLineWidth));
+    painter.drawLine(QPointF(m_playheadX, playheadTop),
+                     QPointF(m_playheadX, m_playheadGeometry.bottom()));
+
+    QPainterPath triangle;
+    triangle.moveTo(m_playheadX - 4, playheadTop);
+    triangle.lineTo(m_playheadX + 4, playheadTop);
+    triangle.lineTo(m_playheadX, playheadTop + 8);
+    triangle.closeSubpath();
+    painter.fillPath(triangle, m_color);
+}
+
+QRect PlayheadOverlay::surfaceGeometry(const QWidget *surface) const
+{
+    const QWidget *owner = parentWidget();
+    return QRect(surface->mapTo(owner, QPoint(0, 0)), surface->size());
+}
+
+QRegion PlayheadOverlay::visibleSurfaceRegion(const QWidget *surface, int origin) const
+{
+    const QWidget *owner = parentWidget();
+    if (origin >= surface->width())
+        return {};
+
+    QRegion visible(QRect(surface->mapTo(owner, QPoint(origin, 0)),
+                          QSize(surface->width() - origin, surface->height())));
+    for (const QWidget *widget = surface; widget; widget = widget->parentWidget()) {
+        if (!widget->isVisible())
+            return {};
+
+        visible &= QRect(widget->mapTo(owner, QPoint(0, 0)), widget->size());
+        if (widget == owner)
+            break;
+    }
+    return visible;
+}
+
+QRegion PlayheadOverlay::playheadRegion(qreal x) const
+{
+    if (m_playheadGeometry.isEmpty())
+        return {};
+
+    constexpr qreal kAntialiasPadding = 1.0;
+    const QRect bounds =
+        QRectF(x - kPlayheadHalfWidth - kAntialiasPadding,
+               m_playheadGeometry.top(),
+               kPlayheadHalfWidth * 2.0 + kAntialiasPadding * 2.0,
+               m_playheadGeometry.height())
+            .toAlignedRect()
+            .intersected(m_playheadGeometry);
+    return QRegion(bounds).intersected(m_visibleSurfaceRegion);
+}
+
+void PlayheadOverlay::synchronizeGeometry()
+{
+    QWidget *owner = parentWidget();
+    Q_ASSERT(owner);
+
+    const QRegion oldVisibleSurfaceRegion = m_visibleSurfaceRegion;
+    const QRect rollGeometry = surfaceGeometry(m_surfaces.roll);
+    const QRect playheadGeometry(0, rollGeometry.top(), owner->width(),
+                                 owner->height() - rollGeometry.top());
+    const QRegion visibleSurfaces =
+        visibleSurfaceRegion(m_surfaces.roll, m_surfaces.rollOrigin)
+        + visibleSurfaceRegion(m_surfaces.lanes, m_surfaces.lanesOrigin)
+        + visibleSurfaceRegion(m_surfaces.strip, m_surfaces.stripOrigin);
+    const int timelineOrigin =
+        m_surfaces.ruler->mapTo(owner, QPoint(m_surfaces.rulerOrigin, 0)).x();
+    const bool overlayGeometryChanged = geometry() != owner->rect();
+    const bool surfaceGeometryChanged =
+        m_playheadGeometry != playheadGeometry
+        || m_visibleSurfaceRegion != visibleSurfaces
+        || m_timelineOrigin != timelineOrigin;
+
+    if (overlayGeometryChanged)
+        setGeometry(owner->rect());
+
+    m_visibleSurfaceRegion = visibleSurfaces;
+    m_playheadGeometry = playheadGeometry;
+    m_timelineOrigin = timelineOrigin;
+    m_playheadX = qreal(m_timelineOrigin) + m_playheadContentX;
+
+    if (overlayGeometryChanged || surfaceGeometryChanged) {
+        update(oldVisibleSurfaceRegion.united(m_visibleSurfaceRegion));
+        raise();
+    }
+}
+
+} // namespace songview

--- a/src/ui/playheadoverlay.cpp
+++ b/src/ui/playheadoverlay.cpp
@@ -10,20 +10,46 @@ namespace songview {
 
 namespace {
 
-constexpr int kGlowWidth = 7;
-constexpr int kPlayheadHalfWidth = kGlowWidth;
-constexpr int kLineWidth = 1;
-constexpr int kTriangleHalfWidth = 4;
-constexpr int kTriangleHeight = 8;
+// Paused = centered on the bar, dimmer. Playing = 1 unit less radius and
+// left-trailing only. Core is 1px in both states.
+constexpr qreal kLineWidth = 1.0;
+constexpr qreal kPeakPlaying = 0.13;
+constexpr qreal kPeakPaused = 0.06;
 
 const QPainterPath kPlayheadTriangle = [] {
     QPainterPath path;
-    path.moveTo(-kTriangleHalfWidth, 0);
-    path.lineTo(kTriangleHalfWidth, 0);
-    path.lineTo(0, kTriangleHeight);
+    path.moveTo(-kPlayheadTriangleHalfWidth, 0);
+    path.lineTo(kPlayheadTriangleHalfWidth, 0);
+    path.lineTo(0, kPlayheadTriangleHeight);
     path.closeSubpath();
     return path;
 }();
+
+// Quadratic bloom: t=0 outer (α=0) → t=1 at the bar (α=peak).
+void setQuadStops(QLinearGradient &g, const QColor &color, qreal peakAlpha)
+{
+    QColor stopColor = color;
+    for (int i = 0; i <= 8; ++i) {
+        const qreal t = qreal(i) / 8.0;
+        stopColor.setAlphaF(peakAlpha * t * t);
+        g.setColorAt(t, stopColor);
+    }
+}
+
+void paintGlow(QPainter &painter, qreal x, int top, int height, qreal left,
+               qreal right, const QColor &color, qreal peakAlpha)
+{
+    if (left > 0.0) {
+        QLinearGradient gradient(x - left, 0, x, 0);
+        setQuadStops(gradient, color, peakAlpha);
+        painter.fillRect(QRectF(x - left, top, left, height), gradient);
+    }
+    if (right > 0.0) {
+        QLinearGradient gradient(x + right, 0, x, 0);
+        setQuadStops(gradient, color, peakAlpha);
+        painter.fillRect(QRectF(x, top, right, height), gradient);
+    }
+}
 
 } // namespace
 
@@ -38,28 +64,6 @@ PlayheadOverlay::PlayheadOverlay(QWidget *owner, const Surfaces &surfaces,
     Q_ASSERT(m_surfaces.roll);
     Q_ASSERT(m_surfaces.lanes);
     Q_ASSERT(m_surfaces.strip);
-
-    QColor transparent = color;
-    transparent.setAlpha(0);
-    QColor stoppedGlowColor = color;
-    stoppedGlowColor.setAlphaF(color.alphaF() * 0.2);
-    QColor playingGlowColor = color;
-    playingGlowColor.setAlphaF(color.alphaF() * 0.3);
-    QColor glowAt15Percent = playingGlowColor;
-    glowAt15Percent.setAlphaF(playingGlowColor.alphaF() * 0.15);
-    QColor glowAt75Percent = playingGlowColor;
-    glowAt75Percent.setAlphaF(playingGlowColor.alphaF() * 0.75);
-    QLinearGradient playingGlow(0, 0, kGlowWidth, 0);
-    playingGlow.setColorAt(0, transparent);
-    playingGlow.setColorAt(0.5, glowAt15Percent);
-    playingGlow.setColorAt(0.75, glowAt75Percent);
-    playingGlow.setColorAt(1.0 - 1.0 / kGlowWidth, playingGlowColor);
-    m_playingGlow = QBrush(playingGlow);
-    QLinearGradient stoppedGlow(0, 0, kGlowWidth, 0);
-    stoppedGlow.setColorAt(0, transparent);
-    stoppedGlow.setColorAt(0.5, stoppedGlowColor);
-    stoppedGlow.setColorAt(0.65, transparent);
-    m_stoppedGlow = QBrush(stoppedGlow);
 
     setAttribute(Qt::WA_TransparentForMouseEvents);
     setAttribute(Qt::WA_NoSystemBackground);
@@ -82,23 +86,23 @@ PlayheadOverlay::PlayheadOverlay(QWidget *owner, const Surfaces &surfaces,
 
 void PlayheadOverlay::setPlayhead(qreal timelineX, bool visible, bool playing)
 {
-    const qreal oldX = m_playheadX;
+    const qreal oldX = qreal(m_timelineOrigin) + m_timelineX;
     const bool oldVisible = m_visible;
     const bool oldPlaying = m_playing;
 
     m_timelineX = timelineX;
-    m_playheadX = qreal(m_timelineOrigin) + timelineX;
     m_visible = visible;
     m_playing = playing;
+    const qreal newX = qreal(m_timelineOrigin) + m_timelineX;
 
-    if (oldX == m_playheadX && oldVisible == m_visible && oldPlaying == m_playing)
+    if (oldX == newX && oldVisible == m_visible && oldPlaying == m_playing)
         return;
 
     QRegion dirty;
     if (oldVisible)
         dirty += playheadRegion(oldX);
     if (m_visible)
-        dirty += playheadRegion(m_playheadX);
+        dirty += playheadRegion(newX);
     if (!dirty.isEmpty())
         update(dirty);
 }
@@ -130,37 +134,32 @@ void PlayheadOverlay::paintEvent(QPaintEvent *)
     painter.setRenderHint(QPainter::Antialiasing);
 
     const int playheadTop = m_playheadGeometry.top();
-    const qreal glowOffset = m_playing ? kGlowWidth : kGlowWidth / 2.0;
-    const qreal glowStartX = m_playheadX - glowOffset;
-    const QBrush &glow = m_playing ? m_playingGlow : m_stoppedGlow;
-    painter.save();
-    painter.translate(glowStartX, playheadTop);
-    painter.fillRect(0, 0, kGlowWidth, m_playheadGeometry.height(), glow);
-    painter.restore();
+    const int height = m_playheadGeometry.height();
+    const qreal playheadX = qreal(m_timelineOrigin) + m_timelineX;
+    const qreal leftExtent =
+        m_playing ? qreal(kPlayheadGlowRadius - 1) : qreal(kPlayheadGlowRadius);
+    const qreal rightExtent = m_playing ? 0.0 : qreal(kPlayheadGlowRadius);
+    const qreal peak = m_playing ? kPeakPlaying : kPeakPaused;
+    paintGlow(painter, playheadX, playheadTop, height, leftExtent, rightExtent,
+              m_color, peak);
 
-    painter.setPen(QPen(m_color, kLineWidth));
-    painter.drawLine(QPointF(m_playheadX, playheadTop),
-                     QPointF(m_playheadX, m_playheadGeometry.bottom()));
+    QPen core(m_color, kLineWidth, Qt::SolidLine, Qt::FlatCap);
+    painter.setPen(core);
+    painter.drawLine(QPointF(playheadX, playheadTop),
+                     QPointF(playheadX, m_playheadGeometry.bottom()));
 
-    painter.save();
     painter.setClipRect(m_triangleClip, Qt::ReplaceClip);
     const bool trianglePointsUp = !m_surfaces.roll->isVisible();
-    painter.translate(m_playheadX, playheadTop
-                                      + (trianglePointsUp ? kTriangleHeight : 0));
+    painter.translate(
+        playheadX, playheadTop + (trianglePointsUp ? kPlayheadTriangleHeight : 0));
     if (trianglePointsUp)
         painter.scale(1.0, -1.0);
     painter.fillPath(kPlayheadTriangle, m_color);
-    painter.restore();
 }
 
-QRect PlayheadOverlay::surfaceGeometry(const QWidget *surface, QWidget *owner) const
+QRect PlayheadOverlay::visibleSurfaceRect(const QWidget *surface, QWidget *owner,
+                                          int origin) const
 {
-    return QRect(surface->mapTo(owner, QPoint(0, 0)), surface->size());
-}
-
-QRect PlayheadOverlay::visibleSurfaceRegion(const QWidget *surface, int origin) const
-{
-    const QWidget *owner = parentWidget();
     if (origin >= surface->width())
         return {};
     QPoint offset = surface->mapTo(owner, QPoint(0, 0));
@@ -183,10 +182,12 @@ QRegion PlayheadOverlay::playheadRegion(qreal x) const
         return {};
 
     constexpr qreal kAntialiasPadding = 1.0;
+    // Max extent is the paused centered bloom (radius each side).
     const QRect bounds =
-        QRectF(x - kPlayheadHalfWidth - kAntialiasPadding,
+        QRectF(x - kPlayheadGlowRadius - kAntialiasPadding,
                m_playheadGeometry.top(),
-               kPlayheadHalfWidth * 2.0 + kAntialiasPadding * 2.0,
+               2.0 * kPlayheadGlowRadius + kPlayheadTriangleHalfWidth
+                   + kAntialiasPadding * 2.0,
                m_playheadGeometry.height())
             .toAlignedRect()
             .intersected(m_playheadGeometry);
@@ -198,18 +199,19 @@ void PlayheadOverlay::synchronizeGeometry()
     QWidget *owner = parentWidget();
     Q_ASSERT(owner);
 
-    const QRect rulerGeometry = surfaceGeometry(m_surfaces.ruler, owner);
+    const QRect rulerGeometry(m_surfaces.ruler->mapTo(owner, QPoint(0, 0)),
+                              m_surfaces.ruler->size());
     const int playheadTop = rulerGeometry.bottom() + 1;
     const QRect playheadGeometry(0, playheadTop, owner->width(),
                                  owner->height() - playheadTop);
     const QRect rulerVisible =
-        visibleSurfaceRegion(m_surfaces.ruler, m_surfaces.rulerOrigin);
+        visibleSurfaceRect(m_surfaces.ruler, owner, m_surfaces.rulerOrigin);
     const QRect triangleClip(rulerVisible.left(), playheadTop,
-                             rulerVisible.width(), kTriangleHeight + 1);
+                             rulerVisible.width(), kPlayheadTriangleHeight + 1);
     const QRegion visibleSurfaces =
-        QRegion(visibleSurfaceRegion(m_surfaces.roll, m_surfaces.rollOrigin))
-        + visibleSurfaceRegion(m_surfaces.lanes, m_surfaces.lanesOrigin)
-        + visibleSurfaceRegion(m_surfaces.strip, m_surfaces.stripOrigin);
+        QRegion(visibleSurfaceRect(m_surfaces.roll, owner, m_surfaces.rollOrigin))
+        + visibleSurfaceRect(m_surfaces.lanes, owner, m_surfaces.lanesOrigin)
+        + visibleSurfaceRect(m_surfaces.strip, owner, m_surfaces.stripOrigin);
     const int timelineOrigin =
         m_surfaces.ruler->mapTo(owner, QPoint(m_surfaces.rulerOrigin, 0)).x();
     const bool overlayGeometryChanged = geometry() != owner->rect();
@@ -220,7 +222,8 @@ void PlayheadOverlay::synchronizeGeometry()
         || m_timelineOrigin != timelineOrigin;
     if (!overlayGeometryChanged && !surfaceGeometryChanged)
         return;
-    const QRegion oldDirty = m_visible ? playheadRegion(m_playheadX) : QRegion();
+    const qreal oldX = qreal(m_timelineOrigin) + m_timelineX;
+    const QRegion oldDirty = m_visible ? playheadRegion(oldX) : QRegion();
 
     if (overlayGeometryChanged)
         setGeometry(owner->rect());
@@ -229,16 +232,13 @@ void PlayheadOverlay::synchronizeGeometry()
     m_playheadGeometry = playheadGeometry;
     m_triangleClip = triangleClip;
     m_timelineOrigin = timelineOrigin;
-    m_playheadX = qreal(m_timelineOrigin) + m_timelineX;
 
-    if (overlayGeometryChanged || surfaceGeometryChanged) {
-        const QRegion dirty =
-            (oldDirty | (m_visible ? playheadRegion(m_playheadX) : QRegion()))
-                - rulerGeometry;
-        if (!dirty.isEmpty())
-            update(dirty);
-        raise();
-    }
+    const qreal newX = qreal(m_timelineOrigin) + m_timelineX;
+    const QRegion dirty =
+        (oldDirty | (m_visible ? playheadRegion(newX) : QRegion())) - rulerGeometry;
+    if (!dirty.isEmpty())
+        update(dirty);
+    raise();
 }
 
 } // namespace songview

--- a/src/ui/playheadoverlay.cpp
+++ b/src/ui/playheadoverlay.cpp
@@ -13,6 +13,17 @@ namespace {
 constexpr int kGlowWidth = 7;
 constexpr int kPlayheadHalfWidth = kGlowWidth;
 constexpr int kLineWidth = 1;
+constexpr int kTriangleHalfWidth = 4;
+constexpr int kTriangleHeight = 8;
+
+const QPainterPath kPlayheadTriangle = [] {
+    QPainterPath path;
+    path.moveTo(-kTriangleHalfWidth, 0);
+    path.lineTo(kTriangleHalfWidth, 0);
+    path.lineTo(0, kTriangleHeight);
+    path.closeSubpath();
+    return path;
+}();
 
 } // namespace
 
@@ -69,14 +80,14 @@ PlayheadOverlay::PlayheadOverlay(QWidget *owner, const Surfaces &surfaces,
     show();
 }
 
-void PlayheadOverlay::setPlayhead(qreal contentX, bool visible, bool playing)
+void PlayheadOverlay::setPlayhead(qreal timelineX, bool visible, bool playing)
 {
     const qreal oldX = m_playheadX;
     const bool oldVisible = m_visible;
     const bool oldPlaying = m_playing;
 
-    m_playheadContentX = contentX;
-    m_playheadX = qreal(m_timelineOrigin) + contentX;
+    m_timelineX = timelineX;
+    m_playheadX = qreal(m_timelineOrigin) + timelineX;
     m_visible = visible;
     m_playing = playing;
 
@@ -110,8 +121,8 @@ bool PlayheadOverlay::eventFilter(QObject *, QEvent *event)
 
 void PlayheadOverlay::paintEvent(QPaintEvent *)
 {
-    if (!m_visible || m_visibleSurfaceRegion.isEmpty()
-        || m_playheadGeometry.isEmpty())
+    if (!m_visible || m_playheadGeometry.isEmpty()
+        || (m_visibleSurfaceRegion.isEmpty() && m_triangleClip.isEmpty()))
         return;
 
     QPainter painter(this);
@@ -131,28 +142,30 @@ void PlayheadOverlay::paintEvent(QPaintEvent *)
     painter.drawLine(QPointF(m_playheadX, playheadTop),
                      QPointF(m_playheadX, m_playheadGeometry.bottom()));
 
-    QPainterPath triangle;
-    triangle.moveTo(m_playheadX - 4, playheadTop);
-    triangle.lineTo(m_playheadX + 4, playheadTop);
-    triangle.lineTo(m_playheadX, playheadTop + 8);
-    triangle.closeSubpath();
-    painter.fillPath(triangle, m_color);
+    painter.save();
+    painter.setClipRect(m_triangleClip, Qt::ReplaceClip);
+    const bool trianglePointsUp = !m_surfaces.roll->isVisible();
+    painter.translate(m_playheadX, playheadTop
+                                      + (trianglePointsUp ? kTriangleHeight : 0));
+    if (trianglePointsUp)
+        painter.scale(1.0, -1.0);
+    painter.fillPath(kPlayheadTriangle, m_color);
+    painter.restore();
 }
 
-QRect PlayheadOverlay::surfaceGeometry(const QWidget *surface) const
+QRect PlayheadOverlay::surfaceGeometry(const QWidget *surface, QWidget *owner) const
 {
-    const QWidget *owner = parentWidget();
     return QRect(surface->mapTo(owner, QPoint(0, 0)), surface->size());
 }
 
-QRegion PlayheadOverlay::visibleSurfaceRegion(const QWidget *surface, int origin) const
+QRect PlayheadOverlay::visibleSurfaceRegion(const QWidget *surface, int origin) const
 {
     const QWidget *owner = parentWidget();
     if (origin >= surface->width())
         return {};
-
-    QRegion visible(QRect(surface->mapTo(owner, QPoint(origin, 0)),
-                          QSize(surface->width() - origin, surface->height())));
+    QPoint offset = surface->mapTo(owner, QPoint(0, 0));
+    QRect visible(offset + QPoint(origin, 0),
+                  QSize(surface->width() - origin, surface->height()));
     for (const QWidget *widget = surface; widget; widget = widget->parentWidget()) {
         if (!widget->isVisible())
             return {};
@@ -177,7 +190,7 @@ QRegion PlayheadOverlay::playheadRegion(qreal x) const
                m_playheadGeometry.height())
             .toAlignedRect()
             .intersected(m_playheadGeometry);
-    return QRegion(bounds).intersected(m_visibleSurfaceRegion);
+    return QRegion(bounds).intersected(m_visibleSurfaceRegion + m_triangleClip);
 }
 
 void PlayheadOverlay::synchronizeGeometry()
@@ -185,18 +198,16 @@ void PlayheadOverlay::synchronizeGeometry()
     QWidget *owner = parentWidget();
     Q_ASSERT(owner);
 
-    const QRegion oldVisibleSurfaceRegion = m_visibleSurfaceRegion;
-    const bool eventListVisible = !m_surfaces.roll->isVisibleTo(owner);
-    const QRect rollGeometry = surfaceGeometry(m_surfaces.roll);
-    const QRect topGeometry =
-        eventListVisible ? surfaceGeometry(m_surfaces.ruler) : rollGeometry;
-    const QRect playheadGeometry(0, topGeometry.top(), owner->width(),
-                                 owner->height() - topGeometry.top());
+    const QRect rulerGeometry = surfaceGeometry(m_surfaces.ruler, owner);
+    const int playheadTop = rulerGeometry.bottom() + 1;
+    const QRect playheadGeometry(0, playheadTop, owner->width(),
+                                 owner->height() - playheadTop);
+    const QRect rulerVisible =
+        visibleSurfaceRegion(m_surfaces.ruler, m_surfaces.rulerOrigin);
+    const QRect triangleClip(rulerVisible.left(), playheadTop,
+                             rulerVisible.width(), kTriangleHeight + 1);
     const QRegion visibleSurfaces =
-        (eventListVisible
-             ? visibleSurfaceRegion(m_surfaces.ruler, m_surfaces.rulerOrigin)
-             : QRegion())
-        + visibleSurfaceRegion(m_surfaces.roll, m_surfaces.rollOrigin)
+        QRegion(visibleSurfaceRegion(m_surfaces.roll, m_surfaces.rollOrigin))
         + visibleSurfaceRegion(m_surfaces.lanes, m_surfaces.lanesOrigin)
         + visibleSurfaceRegion(m_surfaces.strip, m_surfaces.stripOrigin);
     const int timelineOrigin =
@@ -205,18 +216,27 @@ void PlayheadOverlay::synchronizeGeometry()
     const bool surfaceGeometryChanged =
         m_playheadGeometry != playheadGeometry
         || m_visibleSurfaceRegion != visibleSurfaces
+        || m_triangleClip != triangleClip
         || m_timelineOrigin != timelineOrigin;
+    if (!overlayGeometryChanged && !surfaceGeometryChanged)
+        return;
+    const QRegion oldDirty = m_visible ? playheadRegion(m_playheadX) : QRegion();
 
     if (overlayGeometryChanged)
         setGeometry(owner->rect());
 
     m_visibleSurfaceRegion = visibleSurfaces;
     m_playheadGeometry = playheadGeometry;
+    m_triangleClip = triangleClip;
     m_timelineOrigin = timelineOrigin;
-    m_playheadX = qreal(m_timelineOrigin) + m_playheadContentX;
+    m_playheadX = qreal(m_timelineOrigin) + m_timelineX;
 
     if (overlayGeometryChanged || surfaceGeometryChanged) {
-        update(oldVisibleSurfaceRegion.united(m_visibleSurfaceRegion));
+        const QRegion dirty =
+            (oldDirty | (m_visible ? playheadRegion(m_playheadX) : QRegion()))
+                - rulerGeometry;
+        if (!dirty.isEmpty())
+            update(dirty);
         raise();
     }
 }

--- a/src/ui/playheadoverlay.h
+++ b/src/ui/playheadoverlay.h
@@ -27,15 +27,15 @@ public:
 
     PlayheadOverlay(QWidget *owner, const Surfaces &surfaces, const QColor &color);
 
-    void setPlayhead(qreal contentX, bool visible, bool playing);
+    void setPlayhead(qreal timelineX, bool visible, bool playing);
 
 protected:
     bool eventFilter(QObject *watched, QEvent *event) override;
     void paintEvent(QPaintEvent *event) override;
 
 private:
-    QRect surfaceGeometry(const QWidget *surface) const;
-    QRegion visibleSurfaceRegion(const QWidget *surface, int origin) const;
+    QRect surfaceGeometry(const QWidget *surface, QWidget *owner) const;
+    QRect visibleSurfaceRegion(const QWidget *surface, int origin) const;
     QRegion playheadRegion(qreal x) const;
     void synchronizeGeometry();
 
@@ -45,7 +45,8 @@ private:
     QBrush m_stoppedGlow;
     QRegion m_visibleSurfaceRegion;
     QRect m_playheadGeometry;
-    qreal m_playheadContentX = 0.0;
+    QRect m_triangleClip;
+    qreal m_timelineX = 0.0;
     qreal m_playheadX = 0.0;
     int m_timelineOrigin = 0;
     bool m_visible = false;

--- a/src/ui/playheadoverlay.h
+++ b/src/ui/playheadoverlay.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <QBrush>
+#include <QColor>
+#include <QRegion>
+#include <QWidget>
+
+class QEvent;
+class QPaintEvent;
+
+namespace songview {
+
+class PlayheadOverlay final : public QWidget
+{
+public:
+    struct Surfaces
+    {
+        QWidget *ruler;
+        int rulerOrigin;
+        QWidget *roll;
+        int rollOrigin;
+        QWidget *lanes;
+        int lanesOrigin;
+        QWidget *strip;
+        int stripOrigin;
+    };
+
+    PlayheadOverlay(QWidget *owner, const Surfaces &surfaces, const QColor &color);
+
+    void setPlayhead(qreal contentX, bool visible, bool playing);
+
+protected:
+    bool eventFilter(QObject *watched, QEvent *event) override;
+    void paintEvent(QPaintEvent *event) override;
+
+private:
+    QRect surfaceGeometry(const QWidget *surface) const;
+    QRegion visibleSurfaceRegion(const QWidget *surface, int origin) const;
+    QRegion playheadRegion(qreal x) const;
+    void synchronizeGeometry();
+
+    Surfaces m_surfaces;
+    QColor m_color;
+    QBrush m_playingGlow;
+    QBrush m_stoppedGlow;
+    QRegion m_visibleSurfaceRegion;
+    QRect m_playheadGeometry;
+    qreal m_playheadContentX = 0.0;
+    qreal m_playheadX = 0.0;
+    int m_timelineOrigin = 0;
+    bool m_visible = false;
+    bool m_playing = false;
+};
+
+} // namespace songview

--- a/src/ui/playheadoverlay.h
+++ b/src/ui/playheadoverlay.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <QBrush>
 #include <QColor>
 #include <QRegion>
 #include <QWidget>
@@ -9,6 +8,10 @@ class QEvent;
 class QPaintEvent;
 
 namespace songview {
+constexpr int kPlayheadGlowRadius = 10;
+constexpr int kPlayheadTriangleHalfWidth = 4;
+constexpr int kPlayheadTriangleHeight = 8;
+
 
 class PlayheadOverlay final : public QWidget
 {
@@ -34,20 +37,17 @@ protected:
     void paintEvent(QPaintEvent *event) override;
 
 private:
-    QRect surfaceGeometry(const QWidget *surface, QWidget *owner) const;
-    QRect visibleSurfaceRegion(const QWidget *surface, int origin) const;
+    QRect visibleSurfaceRect(const QWidget *surface, QWidget *owner,
+                             int origin) const;
     QRegion playheadRegion(qreal x) const;
     void synchronizeGeometry();
 
     Surfaces m_surfaces;
     QColor m_color;
-    QBrush m_playingGlow;
-    QBrush m_stoppedGlow;
     QRegion m_visibleSurfaceRegion;
     QRect m_playheadGeometry;
     QRect m_triangleClip;
     qreal m_timelineX = 0.0;
-    qreal m_playheadX = 0.0;
     int m_timelineOrigin = 0;
     bool m_visible = false;
     bool m_playing = false;

--- a/src/ui/songview.cpp
+++ b/src/ui/songview.cpp
@@ -6,6 +6,7 @@
 #include <QCursor>
 #include <QDialog>
 #include <QDialogButtonBox>
+#include <QEvent>
 #include <QFontMetrics>
 #include <QHBoxLayout>
 #include <QIcon>
@@ -18,6 +19,7 @@
 #include <QMenu>
 #include <QMessageBox>
 #include <QMouseEvent>
+#include <QObject>
 #include <QPaintEvent>
 #include <QPainter>
 #include <QPainterPath>
@@ -41,9 +43,11 @@
 #include <map>
 #include <utility>
 
+
 #include "core/mid2agbtables.h"
 #include "core/songdocument.h"
 #include "ui/eventlistview.h"
+#include "ui/playheadoverlay.h"
 
 namespace songview {
 
@@ -114,8 +118,8 @@ QColor loopFill() { return QColor(255, 200, 60, 16); }
 QColor loopEdge() { return QColor(224, 168, 0); }
 QColor playheadColor() { return QColor(226, 66, 66); }
 
-// Draw the loop-region band and the playhead line across rect. x positions
-// are computed with origin = local x of timeline tick 0's content position.
+// Draw the loop-region band across rect. x positions are
+// computed with origin = local x of timeline tick 0's content position.
 // timeSelCovered says whether this widget (or row) is inside the active time
 // selection's scope, so the selection band tints exactly the covered content.
 void drawOverlays(QPainter &p, const SongView *sv, const QRect &rect, int origin,
@@ -158,18 +162,10 @@ void drawOverlays(QPainter &p, const SongView *sv, const QRect &rect, int origin
                 p.drawLine(x1, rect.top(), x1, rect.bottom());
         }
     }
-
-    // Edit cursor (dashed, theme foreground) under the playback cursor.
-    const int ex = origin + sv->contentX(double(sv->editCursorTick()));
-    if (ex >= rect.left() && ex <= rect.right()) {
+    const int cursorX = origin + sv->contentX(double(sv->editCursorTick()));
+    if (cursorX >= rect.left() && cursorX <= rect.right()) {
         p.setPen(QPen(sv->palette().color(QPalette::WindowText), 1, Qt::DashLine));
-        p.drawLine(ex, rect.top(), ex, rect.bottom());
-    }
-
-    const int px = origin + sv->contentX(sv->playheadTick());
-    if (px >= rect.left() && px <= rect.right()) {
-        p.setPen(QPen(playheadColor(), 1));
-        p.drawLine(px, rect.top(), px, rect.bottom());
+        p.drawLine(cursorX, rect.top(), cursorX, rect.bottom());
     }
 }
 
@@ -509,16 +505,6 @@ protected:
             p.drawLine(sx1, 0, sx1, height() / 2);
         }
 
-        // Playhead handle.
-        const int px = kGutterW + m_sv->contentX(m_sv->playheadTick());
-        if (px >= area.left() && px <= area.right()) {
-            QPainterPath tri;
-            tri.moveTo(px - 4, height() - 12);
-            tri.lineTo(px + 4, height() - 12);
-            tri.lineTo(px, height() - 4);
-            tri.closeSubpath();
-            p.fillPath(tri, playheadColor());
-        }
     }
 
     void wheelEvent(QWheelEvent *event) override
@@ -4227,6 +4213,18 @@ SongView::SongView(QWidget *parent)
 
     m_strip = new OtherStrip(this);
     vbox->addWidget(m_strip);
+    PlayheadOverlay::Surfaces playheadSurfaces;
+    playheadSurfaces.ruler = m_ruler;
+    playheadSurfaces.rulerOrigin = kGutterW;
+    playheadSurfaces.roll = m_roll;
+    playheadSurfaces.rollOrigin = kKeyboardW;
+    playheadSurfaces.lanes = m_lanes;
+    playheadSurfaces.lanesOrigin = kGutterW;
+    playheadSurfaces.strip = m_strip;
+    playheadSurfaces.stripOrigin = kGutterW;
+    m_playheadOverlay =
+        new PlayheadOverlay(this, playheadSurfaces, playheadColor());
+    syncPlayheadOverlay();
 
     m_hbar = new QScrollBar(Qt::Horizontal, this);
     auto *hbarRow = new QHBoxLayout;
@@ -5150,11 +5148,9 @@ void SongView::setPlayheadSample(uint64_t samplePos, bool playing)
         if (px < 0 || px > vw * 85 / 100)
             setHScroll(int(m_playheadTick * m_pxPerTick) - vw / 10);
     }
-    // The event list mirrors the playhead as a tinted row (and follows it
-    // while playing, mirroring the roll's scroll-follow).
     m_events->setPlayheadTick(m_playheadTick, playing);
     m_headers->syncVoices();
-    refreshTimelineViews();
+    syncPlayheadOverlay();
 }
 
 bool SongView::userGestureActive() const
@@ -5162,6 +5158,16 @@ bool SongView::userGestureActive() const
     return (m_ruler && m_ruler->gestureActive())
         || (m_roll && m_roll->gestureActive())
         || (m_lanes && m_lanes->gestureActive());
+}
+
+void SongView::syncPlayheadOverlay()
+{
+    if (m_playheadOverlay) {
+        const qreal playheadX =
+            m_playheadTick * m_pxPerTick - qreal(m_scrollPx);
+        m_playheadOverlay->setPlayhead(
+            playheadX, m_timeline != nullptr, m_playing);
+    }
 }
 
 void SongView::setEditCursorTick(uint64_t tick)
@@ -5720,6 +5726,7 @@ void SongView::refreshTimelineViews()
     m_roll->update();
     m_lanes->update();
     m_strip->update();
+    syncPlayheadOverlay();
 }
 
 void SongView::resizeEvent(QResizeEvent *event)
@@ -5733,4 +5740,5 @@ void SongView::resizeEvent(QResizeEvent *event)
             {std::max(120, m_splitter->height() - kLanesAreaH), kLanesAreaH});
     }
     updateScrollbars();
+    syncPlayheadOverlay();
 }

--- a/src/ui/songview.cpp
+++ b/src/ui/songview.cpp
@@ -4224,7 +4224,6 @@ SongView::SongView(QWidget *parent)
     playheadSurfaces.stripOrigin = kGutterW;
     m_playheadOverlay =
         new PlayheadOverlay(this, playheadSurfaces, playheadColor());
-    syncPlayheadOverlay();
 
     m_hbar = new QScrollBar(Qt::Horizontal, this);
     auto *hbarRow = new QHBoxLayout;
@@ -5163,10 +5162,10 @@ bool SongView::userGestureActive() const
 void SongView::syncPlayheadOverlay()
 {
     if (m_playheadOverlay) {
-        const qreal playheadX =
+        const qreal timelineX =
             m_playheadTick * m_pxPerTick - qreal(m_scrollPx);
         m_playheadOverlay->setPlayhead(
-            playheadX, m_timeline != nullptr, m_playing);
+            timelineX, m_timeline != nullptr, m_playing);
     }
 }
 

--- a/src/ui/songview.h
+++ b/src/ui/songview.h
@@ -30,6 +30,7 @@ class TimeRuler;
 class PianoRoll;
 class AutomationArea;
 class OtherStrip;
+class PlayheadOverlay;
 class TrackHeaderPanel;
 
 // Fixed gutter geometry shared by every timeline-aligned child: the track
@@ -456,6 +457,7 @@ private:
     // A mouse gesture is live in the ruler, roll, or lanes (pan, drag,
     // sweep); playhead follow-scroll pauses while one runs.
     bool userGestureActive() const;
+    void syncPlayheadOverlay();
     int viewportWidth() const;
     void setHScroll(int px);
     void updateScrollbars();
@@ -501,6 +503,7 @@ private:
     QSplitter *m_splitter = nullptr; // roll above, lanes area below
     bool m_splitInit = false;        // initial sizes applied on first layout
     songview::OtherStrip *m_strip = nullptr;
+    songview::PlayheadOverlay *m_playheadOverlay = nullptr;
     QScrollBar *m_hbar = nullptr;
     QScrollBar *m_vbar = nullptr;
 };


### PR DESCRIPTION
This PR proposes 2 things:
1. Putting the playhead in it's own overlay so the whole SongGrid isn't redrawn when the playhead moves.
2. Making the playhead move at ~60hz 
The selling point for No. 1 is that, depending on the song, it can reduce CPU time by 25-75%.
For No. 2, it makes Porydaw look high-dollar.
Video of it in 60 FPS :

https://github.com/user-attachments/assets/ba63cffe-bace-4b02-abcc-753a23ba49e3

A side-by-side would be a better sell, but im out of space on my machine and I can't make a long enough video - Instrument traces are huuuge.
Notice the playhead no longer renders on the Time Ruler because, at one point, I moved it  off the Time Ruler to keep the ruler from having to rerender. However, now the Playhead  can draw over the Time Ruler no problem, no extra CPU - your call.

Below are Time Profiles showing a run of upstream vs this branch, each playing 5 seconds of audio.:
First two are Upstream
<img width="1396" height="648" alt="Screenshot 2026-07-20 at 9 36 37 PM" src="https://github.com/user-attachments/assets/b3e75920-9de9-4d53-aa04-3b3103c37ca9" />
<img width="1396" height="648" alt="Screenshot 2026-07-20 at 9 36 35 PM" src="https://github.com/user-attachments/assets/8da66d2f-f2c9-47e2-be7a-090949eb347f" />

This is this branch
<img width="1396" height="648" alt="Screenshot 2026-07-20 at 9 36 31 PM" src="https://github.com/user-attachments/assets/27367495-dea6-409e-9ab2-82e03fa7eaca" />
<img width="1396" height="648" alt="Screenshot 2026-07-20 at 9 36 33 PM" src="https://github.com/user-attachments/assets/c84831a7-a48d-4e1c-b9ba-650ff6b23f36" />

I have a lot more traces that show other indicators of a huge performance increase, but these are the cleanest - though they admittedly look like im hyper focused on Time Profiler...