### PR TITLE
Async audio seeks, make moving playhead feel snappier

### DIFF
--- a/src/audio/audioengine.cpp
+++ b/src/audio/audioengine.cpp
@@ -133,6 +133,7 @@ void AudioEngine::loadSong(const MidiTimeline *timeline, LoadedVoiceGroup *voice
     // Cold swap: the audio thread must not be running while pointers change.
     if (m_deviceStarted)
         ma_device_stop(m_device);
+    m_pendingSeek.store(kNoPendingSeek, std::memory_order_release);
 
     m_timeline = timeline;
     m_voicegroup = voicegroup;
@@ -179,6 +180,7 @@ void AudioEngine::updateTimeline(const MidiTimeline *timeline)
         return;
     if (m_deviceStarted)
         ma_device_stop(m_device);
+    m_pendingSeek.store(kNoPendingSeek, std::memory_order_release);
 
     const uint64_t pos = m_player.position();
     m_timeline = timeline;
@@ -203,12 +205,16 @@ void AudioEngine::seek(uint64_t samplePos)
 {
     if (!m_timeline)
         return;
-    if (m_deviceStarted)
-        ma_device_stop(m_device);
+    m_pendingSeek.store(samplePos, std::memory_order_release);
+}
 
-    // Same recipe as updateTimeline: release sounding notes (their note-offs
-    // are behind the new position) and chase so controller state is exact at
-    // the landing position.
+void AudioEngine::applyPendingSeek()
+{
+    const uint64_t samplePos =
+        m_pendingSeek.exchange(kNoPendingSeek, std::memory_order_acq_rel);
+    if (samplePos == kNoPendingSeek || !m_timeline)
+        return;
+
     for (int track = 0; track < MAX_TRACKS; track++)
         m4a_engine_all_notes_off(m_engine.get(), track);
     clearTimedPreviews();
@@ -216,9 +222,6 @@ void AudioEngine::seek(uint64_t samplePos)
     TimelinePlayer::chase(m_engine.get(), m_timeline, samplePos);
     TimelinePlayer::primeVoices(m_engine.get(), m_timeline, samplePos);
     m_playhead.store(samplePos);
-
-    if (m_deviceStarted)
-        ma_device_start(m_device);
 }
 
 void AudioEngine::updateSettings(const SongSettings &settings)
@@ -313,6 +316,7 @@ void AudioEngine::unloadSong()
 {
     if (m_deviceStarted)
         ma_device_stop(m_device);
+    m_pendingSeek.store(kNoPendingSeek, std::memory_order_release);
     m_timeline = nullptr;
     m_voicegroup = nullptr;
     m4a_engine_set_voicegroup(m_engine.get(), nullptr);
@@ -340,6 +344,7 @@ void AudioEngine::pause()
 
 void AudioEngine::stop()
 {
+    m_pendingSeek.store(kNoPendingSeek, std::memory_order_release);
     m_transport.store(static_cast<int>(Transport::Stopped));
 }
 
@@ -604,6 +609,7 @@ void AudioEngine::applyPolyDebug()
 void AudioEngine::process(float *interleavedOut, uint32_t frameCount)
 {
     applyTransportTransition();
+    applyPendingSeek();
     applyMuteTransition();
     applyPreviewNote();
     applyTimedPreviews(frameCount);

--- a/src/audio/audioengine.h
+++ b/src/audio/audioengine.h
@@ -70,10 +70,8 @@ public:
     // Borrowed like loadSong's; the old timeline may be freed once this
     // returns.
     void updateTimeline(const MidiTimeline *timeline);
-    // Cold: jumps the playhead. Releases sounding notes and chases controller
-    // state so CC/program/bend/tempo are exact at the landing position. Works
-    // in any transport state; playing from Stopped starts wherever the last
-    // seek (or the stop-time reset to 0) left the playhead.
+    // Hot: requests a jump at the next audio callback. Releases sounding
+    // notes and chases controller state at the landing position.
     void seek(uint64_t samplePos);
     // Cold: re-applies song settings (master volume, reverb) to the engine.
     void updateSettings(const SongSettings &settings);
@@ -198,6 +196,7 @@ private:
     static void dataCallback(ma_device *device, void *output, const void *input,
                              uint32_t frameCount);
     void process(float *interleavedOut, uint32_t frameCount);
+    void applyPendingSeek();
     void applyTransportTransition();
     void cutAllSound();
     void applyMuteTransition();
@@ -233,6 +232,9 @@ private:
     std::atomic<bool> m_loopEnabled{true};
     std::atomic<uint32_t> m_muteMask{0};
     std::atomic<uint32_t> m_soloMask{0};
+    // Avoid stop/start stalls: publish the latest seek for the audio callback.
+    static constexpr uint64_t kNoPendingSeek = UINT64_MAX;
+    std::atomic<uint64_t> m_pendingSeek{kNoPendingSeek};
     // Preview-note command: generation<<24 | track<<16 | key<<8 | velocity.
     // The generation counter makes every request distinct so repeated notes
     // are seen by the audio thread.

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -717,20 +717,27 @@ SongSession *MainWindow::createSession()
     });
     // Moving the edit cursor while playing (or paused) seeks playback there,
     // chasing controller state to the landing position.
-    connect(s->view, &SongView::editCursorMoved, this, [this, s](uint64_t tick) {
-        if (s == m_active && m_audioOk && m_audio.songLoaded()
-            && m_audio.transport() != Transport::Stopped) {
-            m_audio.seek(m_audio.timeline()->sampleForTick(tick));
-            synchronizePlayhead();
-        }
-    });
+    connect(s->view, &SongView::editCursorMoved, this,
+            [this, s](uint64_t tick) {
+              if (s == m_active && m_audioOk && m_audio.songLoaded() &&
+                  m_audio.transport() != Transport::Stopped) {
+                const uint64_t targetSample =
+                    m_audio.timeline()->sampleForTick(tick);
+                m_audio.seek(targetSample);
+                if (m_audio.transport() == Transport::Paused)
+                  s->view->setPlayheadSample(targetSample, false);
+                else
+                  synchronizePlayhead();
+              }
+            });
     connect(&s->doc, &SongDocument::documentChanged, this,
             [this, s] { onDocumentChanged(*s); });
-    connect(s->doc.undoStack(), &QUndoStack::cleanChanged, this, [this, s](bool) {
-        updateTabTitle(*s);
-        if (s == m_active)
-            updateWindowTitle();
-    });
+    connect(s->doc.undoStack(), &QUndoStack::cleanChanged, this,
+            [this, s](bool) {
+              updateTabTitle(*s);
+              if (s == m_active)
+                updateWindowTitle();
+            });
     m_undoGroup->addStack(s->doc.undoStack());
     m_sessions.push_back(std::move(owned));
     return s;
@@ -2851,31 +2858,83 @@ bool MainWindow::runSelfTest(const QString &projectRoot, const QString &songLabe
     }
 
     const double playedSeconds = double(m_audio.playheadSamples()) / m_audio.sampleRate();
-    qInfo("selftest: after 3s wall clock — playhead %.2fs, transport %d, PCM %d/%d active",
+    qInfo("selftest: after 3s wall clock — playhead %.2fs, transport %d, PCM "
+          "%d/%d active",
           playedSeconds, int(m_audio.transport()), m_audio.activePcmChannels(),
           m_audio.maxPcmChannels());
 
-    bool ok = m_audio.transport() == Transport::Playing && playedSeconds > 1.0
-        && m_audio.playheadSamples() >= posBeforeEdit && vgEditOk;
+    bool ok = m_audio.transport() == Transport::Playing &&
+              playedSeconds > 1.0 &&
+              m_audio.playheadSamples() >= posBeforeEdit && vgEditOk;
     if (ok) {
-        pausePlayback();
-        QTimer::singleShot(150, &loop, &QEventLoop::quit);
-        loop.exec();
-        const uint64_t pausedSample = m_audio.playheadSamples();
-        const double pausedViewTick = tab->view->playheadTick();
-        const double pausedEngineTick =
-            m_audio.timeline()->tickForSample(pausedSample);
-        constexpr double kPausedPlayheadToleranceTicks = 0.25;
-        ok = std::abs(pausedViewTick - pausedEngineTick) <= kPausedPlayheadToleranceTicks;
-        if (!ok) {
-            qWarning("selftest: paused playhead reconciliation FAILED "
-                     "(view %.3f ticks, engine %.3f ticks at %llu samples)",
-                     pausedViewTick, pausedEngineTick,
-                     static_cast<unsigned long long>(pausedSample));
-        }
-        startPlayback();
-    }
+      pausePlayback();
+      QTimer::singleShot(150, &loop, &QEventLoop::quit);
+      loop.exec();
+      const uint64_t pausedSample = m_audio.playheadSamples();
+      const double pausedViewTick = tab->view->playheadTick();
+      const double pausedEngineTick =
+          m_audio.timeline()->tickForSample(pausedSample);
+      constexpr double kPausedPlayheadToleranceTicks = 0.25;
+      ok = std::abs(pausedViewTick - pausedEngineTick) <=
+           kPausedPlayheadToleranceTicks;
+      if (!ok) {
+        qWarning("selftest: paused playhead reconciliation FAILED "
+                 "(view %.3f ticks, engine %.3f ticks at %llu samples)",
+                 pausedViewTick, pausedEngineTick,
+                 static_cast<unsigned long long>(pausedSample));
+      }
 
+      if (ok) {
+        const MidiTimeline *tl = m_audio.timeline();
+        const uint64_t maxTick =
+            (tl && tl->lengthTicks > 0) ? tl->lengthTicks - 1 : 9600;
+        const uint64_t pausedTargetTick =
+            (pausedViewTick >= 960.0)
+                ? static_cast<uint64_t>(pausedViewTick - 480.0)
+                : std::min<uint64_t>(
+                      static_cast<uint64_t>(pausedViewTick + 960.0), maxTick);
+
+        tab->view->commitEditCursor(pausedTargetTick);
+        const double immediateViewTick = tab->view->playheadTick();
+        const bool pausedViewOk =
+            std::abs(immediateViewTick - double(pausedTargetTick)) <=
+            kPausedPlayheadToleranceTicks;
+        if (!pausedViewOk) {
+          qWarning("selftest: paused edit-cursor visible playhead FAILED "
+                   "(target %llu ticks, view %.3f ticks)",
+                   static_cast<unsigned long long>(pausedTargetTick),
+                   immediateViewTick);
+        }
+
+        QTimer::singleShot(200, &loop, &QEventLoop::quit);
+        loop.exec();
+        const uint64_t afterPausedSeekSample = m_audio.playheadSamples();
+        const double afterPausedSeekEngineTick =
+            m_audio.timeline()->tickForSample(afterPausedSeekSample);
+        const bool pausedEngineOk =
+            std::abs(afterPausedSeekEngineTick - double(pausedTargetTick)) <=
+            kPausedPlayheadToleranceTicks;
+        if (!pausedEngineOk) {
+          qWarning("selftest: paused edit-cursor engine seek FAILED "
+                   "(target %llu ticks, engine %.3f ticks at %llu samples)",
+                   static_cast<unsigned long long>(pausedTargetTick),
+                   afterPausedSeekEngineTick,
+                   static_cast<unsigned long long>(afterPausedSeekSample));
+        }
+
+        ok = pausedViewOk && pausedEngineOk;
+        if (ok) {
+          qInfo("selftest: paused edit-cursor seek OK "
+                "(target %llu ticks, view %.3f ticks, engine %.3f ticks)",
+                static_cast<unsigned long long>(pausedTargetTick),
+                immediateViewTick, afterPausedSeekEngineTick);
+        }
+      }
+
+      if (ok) {
+        startPlayback();
+      }
+    }
 
     // M2 polish: edit-cursor seek mid-playback, then play-from-cursor out of
     // Stopped (both go through AudioEngine::seek + chase). Loop disabled so

--- a/src/transportcheck.cpp
+++ b/src/transportcheck.cpp
@@ -137,8 +137,34 @@ int runTransportCheck()
         return 1;
     }
     engine.loadSong(timeline.get(), &tvg.vg, SongSettings{});
+    // Hot seek must only publish a request; restarting the Core Audio device
+    // here used to block the UI thread for tens of milliseconds.
+    qint64 slowestSeekNs = 0;
+    const uint64_t midSong = timeline->lengthSamples / 2;
+    for (int i = 0; i < 5; i++) {
+        QElapsedTimer seekTimer;
+        seekTimer.start();
+        engine.seek(i & 1 ? 0 : midSong);
+        slowestSeekNs = std::max(slowestSeekNs, seekTimer.nsecsElapsed());
+    }
+    if (slowestSeekNs > 20'000'000)
+        fail("seek blocked instead of publishing to the audio thread");
+    if (!waitFor([&] { return engine.playheadSamples() == midSong; }, 2000))
+        fail("audio thread did not apply the latest seek");
+    engine.seek(0);
+    if (!waitFor([&] { return engine.playheadSamples() == 0; }, 2000))
+        fail("audio thread did not apply the reset seek");
 
     const auto active = [&] { return engine.activePcmChannels(); };
+    engine.play();
+    if (!waitFor([&] { return engine.playheadSamples() > 0; }, 2000)) {
+        fail("playback did not start for pending-seek cancellation check");
+    } else {
+        engine.seek(midSong);
+        engine.stop();
+        if (!waitFor([&] { return engine.playheadSamples() == 0; }, 2000))
+            fail("Stop did not cancel a pending seek");
+    }
 
     // A short audition whose note-off has already gone out, leaving a
     // ringing slow-release tail — the reported symptom. Fails the whole


### PR DESCRIPTION
I have some more performance improvements on top of this, but this change touches the audio engine, so it's best to limit the blast radius. 
Currently, seeking via moving the Edit cursor can take 100 ms on an M4 Mac Mini. This change makes it take ~1ms.
This change stores the `seek` position in an atomic that the Audio thread reads on the next `AudioEngine::process` call and goes to that tick. Currently the audio stops and starts whenever the user seeks, this goes around that.
 
 I have tested it and haven't been able to notice an audible delay from this implementation - based on what I believe the code is doing, that would be an artifact of the audio engine applying the `seek` asynchronously from the playhead position.
 
 Time to seek currently:
<img width="1146" height="270" alt="Screenshot 2026-07-24 at 9 22 40 AM" src="https://github.com/user-attachments/assets/01387494-4263-4720-aeb4-74d3fb4aad11" />

Time to seek in this branch:
<img width="1152" height="251" alt="Screenshot 2026-07-24 at 9 22 53 AM" src="https://github.com/user-attachments/assets/40964fad-b301-44bc-a050-b22df00531f3" />

Top-left window is upstream, bottom-right is this branch:

https://github.com/user-attachments/assets/a48c40da-000f-486c-9c6d-72cee9625f69


 Disclosure: I had Codex write this following summary:
 Commit 026d07f: Make audio seeks asynchronous

 Before this change, a seek used this sequence:

 1. Stop the audio device.
 2. Stop all active notes.
 3. Move to the new position.
 4. Restore the MIDI state.
 5. Prepare the voices.
 6. Start the audio device.

 The user interface waited for all these steps. Stopping and starting the audio device caused a noticable delay.

 Now, `AudioEngine::seek()` stores the new position and returns immediately.

 The audio callback applies the seek later. The audio callback does not stop the audio device.

 If the user makes multiple seeks quickly, the engine uses only the latest seek.

 Commit de7e5a3: Fix seeks during pause

 An asynchronous seek caused a display problem during pause.

 The user interface requested a seek. It then read the playhead position before the audio callback completed the seek. Thus, the
 user interface showed the old position.

 The change immediately moves the visible playhead to the requested position during pause.

 The audio callback then updates the audio engine to the same position.

 Result

 - A seek does not stop and start the audio device.
 - A seek does not block the user interface.
 - The visible playhead moves immediately during pause.
 - The audio engine completes the seek in the next audio callback.
 I also had Codex double-check its benchmarks with an adversarial agent second-guessing. Revised benchmarks reflect the vast difference in the screenshots:
# Async Seek Benchmark Results

Date: 2026-07-24

## Results

Two Instruments runs measured the `SongView::commitEditCursor` Points of Interest interval.

| State | Build | Samples | Mean | Median | p95 |
|---|---:|---:|---:|---:|---:|
| Paused | Upstream | 60 | 131.72 ms | 141.16 ms | 220.98 ms |
| Paused | Async | 50 | 68.2 µs | 64.9 µs | 114.8 µs |
| Playing | Upstream | 60 | 169.26 ms | 166.78 ms | 220.01 ms |
| Playing | Async | 60 | 52.4 µs | 48.7 µs | 89.2 µs |

## Difference

### Paused

- Median time saved: **141.09 ms**
- Median interval reduction: **99.95%**
- Median interval was **2,174 times shorter**

### Playing

- Median time saved: **166.73 ms**
- Median interval reduction: **99.97%**
- Median interval was **3,427 times shorter**

## Frame Budget

At 60 Hz:

| State | Upstream median | Async median |
|---|---:|---:|
| Paused | 8.5 frame periods | 0.004 frame periods |
| Playing | 10.0 frame periods | 0.003 frame periods |

All upstream-build samples exceeded both 16.67 ms and 33.33 ms.

No async-build sample exceeded 16.67 ms.

## Workload

- `RelWithDebInfo` builds
- `mus_littleroot`
- Alternating targets at 4 and 16 beats
- Three unmeasured warm-up seeks
- Thirty trials per run
- 75 ms between trials
- Paused and playing measured separately

One repeat async-paused trace attached after ten trials. Therefore, that pooled group contains 50 samples instead of 60.

## Variability

Playing results were consistent between runs.

Upstream paused medians varied:

- Run 1: 157.95 ms
- Run 2: 48.76 ms

The exact paused improvement depends on device stop-and-start behavior. However, every Upstream paused sample still exceeded 33.33 ms. Every async paused sample remained below 0.13 ms.

## Valid Claim

> Async seeking removes approximately 141–167 ms of median main-thread blocking from each accepted cursor seek in this workload.

This benchmark does not measure display presentation or audible latency.
