### PR TITLE
Fix Macos "Shift+Up Arrow" from being interpreted as Numpad arrow

### DIFF
--- a/src/keymapcheck.cpp
+++ b/src/keymapcheck.cpp
@@ -7,6 +7,7 @@
 #include <QLineEdit>
 #include <QPushButton>
 #include <QSettings>
+#include <QScrollBar>
 #include <QTemporaryDir>
 #include <QTreeWidget>
 #include <cstdio>
@@ -336,6 +337,8 @@ int runKeymapCheck()
         // Steal: give Save Song's Ctrl+S to the roll copy command.
         tree->setCurrentItem(findCommandItem(tree, QStringLiteral("roll.copy")));
         capture->setKeySequence(QKeySequence(QStringLiteral("Ctrl+S")));
+        const int scrollBeforeAssign = tree->verticalScrollBar()->maximum() / 2;
+        tree->verticalScrollBar()->setValue(scrollBeforeAssign);
         assignButton->click();
         check(registry.bindings(QStringLiteral("roll.copy"))
                   == QList<QKeySequence>{QKeySequence(QStringLiteral("Ctrl+S"))},
@@ -343,6 +346,8 @@ int runKeymapCheck()
         check(registry.isOverridden(QStringLiteral("file.save_song"))
                   && registry.bindings(QStringLiteral("file.save_song")).isEmpty(),
               "conflicting command was not unbound by the steal");
+        check(tree->verticalScrollBar()->value() == scrollBeforeAssign,
+              "dialog assign did not preserve the list scroll position");
 
         QTreeWidgetItem *copyItem =
             findCommandItem(tree, QStringLiteral("roll.copy"));

--- a/src/keymapcheck.cpp
+++ b/src/keymapcheck.cpp
@@ -377,6 +377,17 @@ int runKeymapCheck()
             const int altIndex =
                 modCapture->findData(int(Qt::AltModifier));
             check(altIndex >= 0, "chord picker offers no Alt");
+#ifdef Q_OS_MACOS
+            const int ctrlShiftIndex = modCapture->findData(
+                int((Qt::ControlModifier | Qt::ShiftModifier).toInt()));
+            check(modCapture->itemText(
+                      modCapture->findData(int(Qt::ControlModifier)))
+                          == QStringLiteral("⌘")
+                      && modCapture->itemText(altIndex) == QStringLiteral("⌥")
+                      && modCapture->itemText(ctrlShiftIndex)
+                          == QStringLiteral("⇧⌘"),
+                  "chord picker does not use native macOS modifier labels");
+#endif
             modCapture->setCurrentIndex(altIndex);
             assignButton->click();
             check(registry.modifierBinding(QStringLiteral("roll.velocity_drag"))
@@ -384,8 +395,13 @@ int runKeymapCheck()
                   "chord picker assign did not apply the modifier");
             QTreeWidgetItem *velItem =
                 findCommandItem(tree, QStringLiteral("roll.velocity_drag"));
+#ifdef Q_OS_MACOS
+            check(velItem && velItem->text(1) == QStringLiteral("⌥"),
+                  "tree does not show the native macOS modifier chord");
+#else
             check(velItem && velItem->text(1) == QStringLiteral("Alt"),
                   "tree does not show the new modifier chord");
+#endif
             tree->setCurrentItem(velItem);
             resetButton->click();
             check(registry.modifierBinding(QStringLiteral("roll.velocity_drag"))

--- a/src/keymapcheck.cpp
+++ b/src/keymapcheck.cpp
@@ -81,6 +81,13 @@ int runKeymapCheck()
         return ok;
     };
 
+#ifdef Q_OS_MACOS
+    const QKeySequence keypadShiftUp(QKeyCombination(
+        Qt::ShiftModifier | Qt::KeypadModifier, Qt::Key_Up));
+    const QKeySequence shiftUp(
+        QKeyCombination(Qt::ShiftModifier, Qt::Key_Up));
+#endif
+
     auto &registry = keymap::Registry::instance();
 
     // 1. Shipped table sanity: unique ids, visible names/categories, and no
@@ -301,6 +308,19 @@ int runKeymapCheck()
             static_cast<QAbstractItemView *>(tree)->sizeHintForColumn(0);
         check(tree->columnWidth(0) >= columnHint,
               "command column narrower than its contents");
+
+#ifdef Q_OS_MACOS
+        tree->setCurrentItem(
+            findCommandItem(tree, QStringLiteral("roll.copy")));
+        capture->setKeySequence(keypadShiftUp);
+        check(capture->keySequence() == shiftUp,
+              "macOS shortcut capture still exposes the keypad modifier");
+        assignButton->click();
+        check(registry.bindings(QStringLiteral("roll.copy"))
+                  == QList<QKeySequence>{shiftUp},
+              "macOS shortcut assignment retained the keypad modifier");
+        registry.resetBinding(QStringLiteral("roll.copy"));
+#endif
 
         filter->setText(QStringLiteral("Transpose"));
         QTreeWidgetItem *findSong =

--- a/src/ui/keyboardshortcutsdialog.cpp
+++ b/src/ui/keyboardshortcutsdialog.cpp
@@ -19,6 +19,24 @@ namespace {
 // The command id lives on the item so filtering/sorting never desyncs it.
 constexpr int kIdRole = Qt::UserRole;
 
+QString modifierDisplayText(Qt::KeyboardModifiers mods)
+{
+#ifdef Q_OS_MACOS
+    QString text;
+    if (mods.testFlag(Qt::MetaModifier))
+        text += QStringLiteral("⌃");
+    if (mods.testFlag(Qt::AltModifier))
+        text += QStringLiteral("⌥");
+    if (mods.testFlag(Qt::ShiftModifier))
+        text += QStringLiteral("⇧");
+    if (mods.testFlag(Qt::ControlModifier))
+        text += QStringLiteral("⌘");
+    return text;
+#else
+    return keymap::Registry::modifierText(mods);
+#endif
+}
+
 QKeySequence capturedKeySequence(const QKeySequence &sequence)
 {
     if (sequence.isEmpty())
@@ -80,7 +98,7 @@ KeyboardShortcutsDialog::KeyboardShortcutsDialog(QWidget *parent)
           Qt::ControlModifier | Qt::ShiftModifier,
           Qt::ControlModifier | Qt::AltModifier,
           Qt::ShiftModifier | Qt::AltModifier}) {
-        m_modCapture->addItem(keymap::Registry::modifierText(mods),
+        m_modCapture->addItem(modifierDisplayText(mods),
                               int(mods.toInt()));
     }
     m_modCapture->hide();
@@ -159,9 +177,9 @@ void KeyboardShortcutsDialog::rebuildTree()
             font.setBold(true);
             categoryItem->setFont(0, font);
         }
-        const QString binding = info.modifier
-            ? keymap::Registry::modifierText(registry.modifierBinding(info.id))
-            : bindingText(registry.bindings(info.id));
+        const QString binding =
+            info.modifier ? modifierDisplayText(registry.modifierBinding(info.id))
+                          : bindingText(registry.bindings(info.id));
         auto *item = new QTreeWidgetItem(categoryItem, {info.name, binding});
         item->setData(0, kIdRole, info.id);
         if (registry.isOverridden(info.id)) {

--- a/src/ui/keyboardshortcutsdialog.cpp
+++ b/src/ui/keyboardshortcutsdialog.cpp
@@ -9,6 +9,7 @@
 #include <QLineEdit>
 #include <QMessageBox>
 #include <QPushButton>
+#include <QScrollBar>
 #include <QTreeWidget>
 #include <QVBoxLayout>
 
@@ -164,6 +165,7 @@ QString KeyboardShortcutsDialog::currentCommandId() const
 void KeyboardShortcutsDialog::rebuildTree()
 {
     const QString selected = currentCommandId();
+    const int scrollPosition = m_tree->verticalScrollBar()->value();
     m_tree->clear();
     auto &registry = keymap::Registry::instance();
     QTreeWidgetItem *categoryItem = nullptr;
@@ -197,6 +199,7 @@ void KeyboardShortcutsDialog::rebuildTree()
         m_tree->setCurrentItem(toReselect);
     else
         currentRowChanged();
+    m_tree->verticalScrollBar()->setValue(scrollPosition);
 }
 
 void KeyboardShortcutsDialog::applyFilter()

--- a/src/ui/keyboardshortcutsdialog.cpp
+++ b/src/ui/keyboardshortcutsdialog.cpp
@@ -19,6 +19,19 @@ namespace {
 // The command id lives on the item so filtering/sorting never desyncs it.
 constexpr int kIdRole = Qt::UserRole;
 
+QKeySequence capturedKeySequence(const QKeySequence &sequence)
+{
+    if (sequence.isEmpty())
+        return {};
+    auto chord = sequence[0];
+#ifdef Q_OS_MACOS
+    auto modifiers = chord.keyboardModifiers();
+    modifiers.setFlag(Qt::KeypadModifier, false);
+    chord = QKeyCombination(modifiers, chord.key());
+#endif
+    return QKeySequence(chord);
+}
+
 QString bindingText(const QList<QKeySequence> &sequences)
 {
     QStringList parts;
@@ -231,11 +244,13 @@ void KeyboardShortcutsDialog::captureChanged()
             id, registry.command(id).context,
             Qt::KeyboardModifiers(QFlag(m_modCapture->currentData().toInt())));
     } else {
-        QKeySequence seq = m_capture->keySequence();
+        const QKeySequence seq = capturedKeySequence(m_capture->keySequence());
         if (seq.isEmpty())
             return;
-        if (seq.count() > 1) // pre-6.4 QKeySequenceEdit records multi-stroke
-            seq = QKeySequence(seq[0].toCombined());
+        if (seq != m_capture->keySequence()) {
+            const QSignalBlocker blocker(m_capture);
+            m_capture->setKeySequence(seq);
+        }
         conflicts = registry.conflicts(id, registry.command(id).context, seq);
     }
     if (conflicts.isEmpty())
@@ -270,9 +285,7 @@ void KeyboardShortcutsDialog::assign()
         rebuildTree();
         return;
     }
-    QKeySequence seq = m_capture->keySequence();
-    if (seq.count() > 1)
-        seq = QKeySequence(seq[0].toCombined());
+    const QKeySequence seq = capturedKeySequence(m_capture->keySequence());
     if (seq.isEmpty())
         return;
     m_applying = true;


### PR DESCRIPTION
I've tested this on Windows on a tenkeyless keyboard - behaves the same as before this patch, as expected.
Before:
<img width="702" height="398" alt="Screenshot 2026-07-26 at 11 03 31 AM" src="https://github.com/user-attachments/assets/e50431b3-01bc-4810-be74-87594db6a6ff" />

https://github.com/user-attachments/assets/2096628d-33c8-4bba-bff4-aed68ee18f45

After:
<img width="724" height="420" alt="Screenshot 2026-07-26 at 10 50 20 AM" src="https://github.com/user-attachments/assets/104fa6ad-e1cc-45bf-9866-5bcd14d34573" />


https://github.com/user-attachments/assets/49484e88-1b00-4b09-8d3b-6cdb289d2796

